### PR TITLE
Set UnauthorizedError status code to 401

### DIFF
--- a/lib/errors/UnauthorizedError.js
+++ b/lib/errors/UnauthorizedError.js
@@ -1,7 +1,7 @@
 function UnauthorizedError (code, error) {
   Error.call(this, error.message);
   this.message = error.message;
-  this.code = code;
+  this.status = 401;
   this.inner = error;
 }
 


### PR DESCRIPTION
So Express.errorHandler can handle it to return 401 Unauthorized Error instead of 500 Internal Server Error (issue #1)
