### PR TITLE
let OPTIONS pass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,13 @@ module.exports = function(options) {
 
   return function(req, res, next) {
     var token;
+    
+    if(req.method === 'OPTIONS' && req.headers.hasOwnProperty('access-control-request-headers')) {
+      if (req.headers['access-control-request-headers'].split(', ').indexOf('authorization') != -1) {
+        return next();
+      }
+    }
+    
     if (req.headers && req.headers.authorization) {
       var parts = req.headers.authorization.split(' ');
       if (parts.length == 2) {


### PR DESCRIPTION
When doing CORS requests, AngularJS sends a preflight OPTIONS request, that does not expose the authorization header. This is standard, please see https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS

Those requests are blocked by express-jwt, even though the following POST / GET request contain the correct header. The existence of authorization headers in the requests following OPTIONS, can be evaluated by checking the contents of OPTIONS request header called Access-Control-Request-Headers. If 'authorization' is inside that header, the following request will contain an Authorization header. There is no way to check if the authorization data is valid, as the OPTIONS request does not expose them. 

This commit allows preflight OPTIONS requests that are passed before GET / POSTS requests that contain the Authorization header.
