### PR TITLE
Better Identification of UnauthroizedError

### DIFF
--- a/lib/errors/UnauthorizedError.js
+++ b/lib/errors/UnauthorizedError.js
@@ -1,5 +1,6 @@
 function UnauthorizedError (code, error) {
   Error.call(this, error.message);
+  this.name = "UnauthorizedError";
   this.message = error.message;
   this.code = code;
   this.status = 401;


### PR DESCRIPTION
Give the error a name so it can be properly identified as an unauthorized request.
