### PR TITLE
Fixed comma handling in access-control-request-headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,11 @@ module.exports = function(options) {
     var token;
     
     if (req.method === 'OPTIONS' && req.headers.hasOwnProperty('access-control-request-headers')) {
-      if (req.headers['access-control-request-headers'].split(', ').indexOf('authorization') != -1) {
-        return next();
-      }
+	for (var ctrlReqs = req.headers['access-control-request-headers'].split(','),i=0;
+	     i < ctrlReqs.length; i++) {
+	    if (ctrlReqs[i].indexOf('authorization') != -1) 
+		return next();
+	}
     }
     
     if (typeof options.skip !== 'undefined') {


### PR DESCRIPTION
Firefox 27 and possibly other browsers sends the access-control-request-headers separated by ',', not ', '
