### PR TITLE
Add secure URL prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example,
 
     var jwt = require('express-jwt');
 
-    app.get('/protected', 
+    app.get('/protected',
       jwt({secret: 'shhhhhhared-secret'}),
       function(req, res) {
         if (!req.user.admin) return res.send(401);
@@ -36,11 +36,15 @@ You can specify audience and/or issuer as well
 
 > If the JWT has an expiration (`exp`), it will be checked.
 
+The `secureUrlPrefix` option will only apply the middleware to paths that begin with the prefix.
+
+    app.use(jwt({ secret: 'shhhhhhared-secret', secureUrlPrefix: '/api'}));
+
 Optionally you can add paths for the middleware to skip
-    
+
     app.use(jwt({ secret: 'shhhhhhared-secret', skip: ['/token']}));
 
-This is especially useful when applying to multiple routes. 
+This is especially useful when applying to multiple routes.
 
 This module also support tokens signed with public/private key pairs. Instead of a secret, you can specify a Buffer with the public key
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,27 +6,33 @@ module.exports = function(options) {
 
   return function(req, res, next) {
     var token;
-    
+
     if (req.method === 'OPTIONS' && req.headers.hasOwnProperty('access-control-request-headers')) {
-	for (var ctrlReqs = req.headers['access-control-request-headers'].split(','),i=0;
-	     i < ctrlReqs.length; i++) {
-	    if (ctrlReqs[i].indexOf('authorization') != -1) 
-		return next();
-	}
+    for (var ctrlReqs = req.headers['access-control-request-headers'].split(','),i=0;
+         i < ctrlReqs.length; i++) {
+        if (ctrlReqs[i].indexOf('authorization') != -1)
+        return next();
     }
-    
+    }
+
+    if (typeof options.secureUrlPrefix !== 'undefined') {
+        if (req.url.indexOf(options.secureUrlPrefix) !== 0) {
+          return next();
+        }
+    }
+
     if (typeof options.skip !== 'undefined') {
       if (options.skip.indexOf(req.url) > -1) {
         return next();
       }
-    } 
-    
+    }
+
     if (req.headers && req.headers.authorization) {
       var parts = req.headers.authorization.split(' ');
       if (parts.length == 2) {
         var scheme = parts[0]
           , credentials = parts[1];
-          
+
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         }


### PR DESCRIPTION
The `secureUrlPrefix` option will only apply the middleware to paths that begin with the prefix. I found this handy while working on a couple of apps that served both a JSON API and template partials. Rather than add a path to the `skip` option for each new partial, I instead apply the middleware to the API routes which all begin with `/api`. In this case, the `skip` option can still be used for more granular exemptions. For example, if my API has an authentication route at `/api/authenticate`, I can simply add it to `skip` as before and everything works as expected.
