### PR TITLE
UnauthorizedError: call captureStackTrace

### DIFF
--- a/lib/errors/UnauthorizedError.js
+++ b/lib/errors/UnauthorizedError.js
@@ -1,5 +1,6 @@
 function UnauthorizedError (code, error) {
   Error.call(this, error.message);
+  Error.captureStackTrace(this, this.constructor);
   this.name = "UnauthorizedError";
   this.message = error.message;
   this.code = code;


### PR DESCRIPTION
Capture the stacktrace when creating an UnauthorizedError.
