### PR TITLE
Add option for alternate property to attach decoded token to on req

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ var publicKey = fs.readFileSync('/pat/to/public.pub');
 jwt({ secret: publicKey });
 ```
 
+By default, the decoded token is attached to `req.user` but can be configured with the `userProperty` option.
+
+```javascript
+jwt({ secret: publicKey, userProperty: 'auth' });
+```
+
 
 ### Error handling
 
@@ -63,7 +69,7 @@ The default behavior is to throw an error when the token is invalid, so you can 
 
 ```javascript
 app.use(function (err, req, res, next) {
-  if (err.name === 'UnauthorizedError') { 
+  if (err.name === 'UnauthorizedError') {
     res.send(401, 'invalid token...');
   }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var unless = require('express-unless');
 module.exports = function(options) {
   if (!options || !options.secret) throw new Error('secret should be set');
 
+  var _userProperty = options.userProperty || 'user';
   var middleware = function(req, res, next) {
     var token;
 
@@ -46,7 +47,7 @@ module.exports = function(options) {
     jwt.verify(token, options.secret, options, function(err, decoded) {
       if (err) return next(new UnauthorizedError('invalid_token', err));
 
-      req.user = decoded;
+      req[_userProperty] = decoded;
       next();
     });
   };

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -129,4 +129,15 @@ describe('work tests', function () {
     });
   });
 
+  it('should set userProperty if option provided', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secret, userProperty: 'auth'})(req, res, function() {
+      assert.equal('bar', req.auth.foo);
+    });
+  });
+
 });


### PR DESCRIPTION
Allow the user to change the `req.user` property to be anything else on `req`.
Based on the approach taken by [Passport](https://github.com/jaredhanson/passport).
