### PR TITLE
Add support for getting the jwt token from the query string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ By default, the decoded token is attached to `req.user` but can be configured wi
 jwt({ secret: publicKey, userProperty: 'auth' });
 ```
 
+### Access token in the query string
+
+You might want to send the access token in the request query string where sending
+a header is hard, e.g. in an html img element.
+
+You can enable this using the option _queryAccessTokenEnabled_, and also configure the query param name with the option _queryAccessTokenName_, which defaults to 'accessToken'.
+
+    app.use(jwt({
+      secret: 'hello world !',
+      queryAccessTokenEnabled: true,
+      queryAccessTokenName: 'jwt'
+    }));
+
+Now also requests of the format http://example.com?jwt=<token> will be authenticated.
 
 ### Error handling
 
@@ -79,7 +93,7 @@ app.use(function (err, req, res, next) {
 You might want to use this module to identify registered users without preventing unregistered clients to access to some data, you
 can do it using the option _credentialsRequired_:
 
-    app.use(jwt({ 
+    app.use(jwt({
       secret: 'hello world !',
       credentialsRequired: false
     }));

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ module.exports = function(options) {
   if (!options || !options.secret) throw new Error('secret should be set');
 
   var _userProperty = options.userProperty || 'user';
+  var _queryAccessTokenName = options.queryAccessTokenName || 'accessToken';
   var middleware = function(req, res, next) {
     var token;
 
@@ -40,6 +41,8 @@ module.exports = function(options) {
       } else {
         return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));
       }
+    } else if (options.queryAccessTokenEnabled === true && req.query && req.query[_queryAccessTokenName]) {
+        token = req.query[_queryAccessTokenName];
     } else if (options.credentialsRequired === false) {
       return next();
     }


### PR DESCRIPTION
Hi,

I added support for sending the jwt token in a query param. It is useful in cases were it's hard to send headers, e.g. img-tags in html.

Any interest in taking in this change? If so, are there any changes needed? Test cases perhaps?

Thanks,
Martin