### PR TITLE
Should not throw exception with invalid token if credentials are not required

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ module.exports = function(options) {
     }
 
     jwt.verify(token, options.secret, options, function(err, decoded) {
-      if (err) return next(new UnauthorizedError('invalid_token', err));
+      if (err && credentialsRequired) return next(new UnauthorizedError('invalid_token', err));
 
       req[_userProperty] = decoded;
       next();

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -172,8 +172,9 @@ describe('work tests', function () {
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function(err) {
+    expressjwt({ secret: secret, credentialsRequired: false })(req, res, function(err) {
       assert(typeof err === 'undefined');
+      assert(typeof req.user === 'undefined')
     });
   });
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -166,6 +166,17 @@ describe('work tests', function () {
     });
   });
 
+  it('should work if token is expired and credentials are not required', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function(err) {
+      assert(typeof err === 'undefined');
+    });
+  });
+
   it('should not work if no authorization header', function() {
     req = {};
     expressjwt({ secret: 'shhhh' })(req, res, function(err) {


### PR DESCRIPTION
I use the express-jwt middleware on all my routes, some routes are public and some are private. So I use ```  credentialsRequired: false``` and in another middleware I limit the access by looking at the ```req.user``` object.

But I noticed that if the user supplies a invalid or expired token the credentialsRequired flag is not being used and the user is blocked access even if that particular route was supposed to be public.