### PR TITLE
Add Additional Error Handling for Format/Scheme

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ module.exports = function(options) {
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         } else {
-          return next(new UnauthorizedError('credentials_bad_scheme', { message: 'Scheme is Bearer'}));
+          return next(new UnauthorizedError('credentials_bad_scheme', { message: 'Scheme is Bearer' }));
         }
       } else {
         return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,8 @@ module.exports = function(options) {
 
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
+        } else {
+          return next(new UnauthorizedError('credentials_bad_scheme', { message: 'Scheme is Bearer'}));
         }
       } else {
         return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));


### PR DESCRIPTION
I found this was a problem when dealing with JWT.  Some clients were submitting with a scheme named something other than Bearer.  I made this change so that the error message showed what was true.  Without this change, the module acts as if there isn't a token being submitted which is incorrect.  Please pull this into main branch.