### PR TITLE
Fix for 'Buffer' secret with new multitenancy callback 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ module.exports = function(options) {
 
   var secretCallback = options.secret;
 
-  if (typeof secretCallback === 'string'){
+  if (typeof secretCallback === 'string' || Buffer.isBuffer(secretCallback)){
     secretCallback = wrapStaticSecretInCallback(secretCallback);
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,11 @@ var async = require('async');
 
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); }
 
+var getClass = {}.toString;
+function isFunction(object) {
+  return object && getClass.call(object) == '[object Function]';
+}
+
 function wrapStaticSecretInCallback(secret){
   return function(_, __, cb){
     return cb(null, secret);
@@ -16,7 +21,7 @@ module.exports = function(options) {
 
   var secretCallback = options.secret;
 
-  if (typeof secretCallback === 'string' || Buffer.isBuffer(secretCallback)){
+  if (!isFunction(secretCallback)){
     secretCallback = wrapStaticSecretInCallback(secretCallback);
   }
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -167,7 +167,18 @@ describe('work tests', function () {
   var res = {};
 
   it('should work if authorization header is valid jwt', function() {
-    var secret = 'shhhhhh';
+    var secret = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secret})(req, res, function() {
+      assert.equal('bar', req.user.foo);
+    });
+  });
+
+  it('should work if authorization header is valid with a buffer secret', function() {
+    var secret = new Buffer('');
     var token = jwt.sign({foo: 'bar'}, secret);
 
     req.headers = {};

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -167,7 +167,7 @@ describe('work tests', function () {
   var res = {};
 
   it('should work if authorization header is valid jwt', function() {
-    var secret = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
     req.headers = {};
@@ -178,7 +178,7 @@ describe('work tests', function () {
   });
 
   it('should work if authorization header is valid with a buffer secret', function() {
-    var secret = new Buffer('');
+    var secret = new Buffer('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'base64');
     var token = jwt.sign({foo: 'bar'}, secret);
 
     req.headers = {};


### PR DESCRIPTION
It appears that since the new multitenancy callback features have gone in, you cannot use the middleware if you provide a secret in the form of a `Buffer`.

This is due to the fact that the code is checking to see if the `secret` is static by checking if it is a string. If so, it is wrapped in a callback function. This is fine unless your `secret` is a `Buffer` in which case it must also be wrapped.

This PR also contains a test which demonstrates the bug (although the test passes because this PR fixes the bug).

The fix is to check to see if the `secret` is a string OR a buffer. Perhaps a better solution is to check to see if `secret` is a callback.

The error you will see is of the form:

```
TypeError: object is not a function
    at async.parallel.revoked (c:\Repositories\GitHub\dwmkerr\onedown\node_modul
es\express-jwt\lib\index.js:84:9)
    at c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-jwt\node_modu
les\async\lib\async.js:570:21
    at c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-jwt\node_modu
les\async\lib\async.js:249:17
    at c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-jwt\node_modu
les\async\lib\async.js:125:13
    at Array.forEach (native)
    at _each (c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-jwt\no
de_modules\async\lib\async.js:46:24)
    at async.each (c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-j
wt\node_modules\async\lib\async.js:124:9)
    at _asyncMap (c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-jw
t\node_modules\async\lib\async.js:248:13)
    at Object.map (c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-j
wt\node_modules\async\lib\async.js:219:23)
    at _parallel (c:\Repositories\GitHub\dwmkerr\onedown\node_modules\express-jw
t\node_modules\async\lib\async.js:568:20)
```

This is perhaps quite an important issue as if you follow the Auth0 guide for setting up a new NodeJS / SPA project then the code generated in the tutorial uses a `Buffer` for a secret, meaning following the tutorial leads to a failing application.