### PR TITLE
Expand on what is possible with path param for unless()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Optionally you can make some paths unprotected as follows:
 app.use(jwt({ secret: 'shhhhhhared-secret'}).unless({path: ['/token']}));
 ```
 
-This is especially useful when applying to multiple routes.
+This is especially useful when applying to multiple routes. `path` can be a string, a regexp or an array of any of those (see [express-unless](https://github.com/jfromaniello/express-unless) for more details).
 
 This module also support tokens signed with public/private key pairs. Instead of a secret, you can specify a Buffer with the public key
 


### PR DESCRIPTION
When I was using this, I couldn't figure out how to exclude wildcard routes until I found this issue: https://github.com/auth0/express-jwt/issues/53. I also didn't realize the `unless()` functionality was based on another module with more options than what is currently described, so I added a line in a README to document that.