### PR TITLE
Optionally pass token headers to secret callback.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,14 +82,19 @@ module.exports = function(options) {
       }
     }
 
-    var payload = jwt.decode(token);
+    var dtoken = jwt.decode(token, { complete: true }) || {};
 
     async.parallel([
       function(callback){
-        secretCallback(req, payload, callback);
+        var arity = secretCallback.length;
+        if (arity == 4) {
+          secretCallback(req, dtoken.header, dtoken.payload, callback);
+        } else { // arity == 3
+          secretCallback(req, dtoken.payload, callback);
+        }
       },
       function(callback){
-        isRevokedCallback(req, payload, callback);
+        isRevokedCallback(req, dtoken.payload, callback);
       }
     ], function(err, results){
       if (err) { return next(err); }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-jwt",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "JWT authentication middleware.",
   "keywords": [
     "auth",

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -243,4 +243,20 @@ describe('work tests', function () {
       assert.equal('bar', req.user.foo);
     });
   });
+  
+  it('should work with a secretCallback function that accepts header argument', function() {
+    var secret = 'shhhhhh';
+    var secretCallback = function(req, headers, payload, cb) {
+      assert.equal(headers.alg, 'HS256');
+      assert.equal(payload.foo, 'bar');
+      process.nextTick(function(){ return cb(null, secret) });
+    }
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secretCallback})(req, res, function() {
+      assert.equal('bar', req.user.foo);
+    });
+  });
 });


### PR DESCRIPTION
Depends on https://github.com/auth0/node-jsonwebtoken/pull/89

This allows the secret callback to inspect token headers (including `kid`), which is needed when fetching keys from a JWKS and supporting key rotation.
