### PR TITLE
Fallback to headers if custom getToken function does not return a token

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,9 @@ module.exports = function(options) {
       } catch (e) {
         return next(e);
       }
-    } else if (req.headers && req.headers.authorization) {
+    }
+
+    if (!token && req.headers && req.headers.authorization) {
       var parts = req.headers.authorization.split(' ');
       if (parts.length == 2) {
         var scheme = parts[0];

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -165,6 +165,11 @@ describe('work tests', function () {
   var req = {};
   var res = {};
 
+  beforeEach(function() {
+    req = {};
+    res = {};
+  });
+
   it('should work if authorization header is valid jwt', function() {
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
@@ -239,6 +244,21 @@ describe('work tests', function () {
     expressjwt({
       secret: secret,
       getToken: getTokenFromQuery
+    })(req, res, function() {
+      assert.equal('bar', req.user.foo);
+    });
+  });
+
+  it('should attempt custom getToken function and fallback to headers if it returns a falsy value', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+
+    expressjwt({
+      secret: secret,
+      getToken: function() { return null; }
     })(req, res, function() {
       assert.equal('bar', req.user.foo);
     });


### PR DESCRIPTION
Also: Fix tests by resetting req and res objects before each test

As mentioned in #78 