### PR TITLE
Make all errors Unauthorized errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ module.exports = function(options) {
         isRevokedCallback(req, dtoken.payload, callback);
       }
     ], function(err, results){
-      if (err) { return next(new UnauthorizedError(err.message, {message: err.message})); }
+      if (err) { return next(new UnauthorizedError(err.code, {message: err.message})); }
       var revoked = results[1];
       if (revoked){
         return next(new UnauthorizedError('revoked_token', { message: 'The token has been revoked.'}));


### PR DESCRIPTION
Hijacks the error on the return from the module. Then sends it up as an UnauthorizedError. This so you your middle ware catching the errors for JWT invalidation will catch it.