### PR TITLE
Update status responses to Express 4.x format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ var jwt = require('express-jwt');
 app.get('/protected',
   jwt({secret: 'shhhhhhared-secret'}),
   function(req, res) {
-    if (!req.user.admin) return res.send(401);
-    res.send(200);
+    if (!req.user.admin) return res.sendStatus(401);
+    res.sendStatus(200);
   });
 ```
 
@@ -113,8 +113,8 @@ var secretCallback = function(req, payload, done){
 app.get('/protected',
   jwt({secret: secretCallback}),
   function(req, res) {
-    if (!req.user.admin) return res.send(401);
-    res.send(200);
+    if (!req.user.admin) return res.sendStatus(401);
+    res.sendStatus(200);
   });
 ```
 
@@ -146,8 +146,8 @@ app.get('/protected',
   jwt({secret: shhhhhhared-secret,
     isRevoked: isRevokedCallback}),
   function(req, res) {
-    if (!req.user.admin) return res.send(401);
-    res.send(200);
+    if (!req.user.admin) return res.sendStatus(401);
+    res.sendStatus(200);
   });
 ```
 
@@ -159,7 +159,7 @@ The default behavior is to throw an error when the token is invalid, so you can 
 ```javascript
 app.use(function (err, req, res, next) {
   if (err.name === 'UnauthorizedError') {
-    res.send(401, 'invalid token...');
+    res.status(401).send('invalid token...');
   }
 });
 ```


### PR DESCRIPTION
- Updated responses to Express 4.x format (`res.sendStatus(status)` [(ref)](http://expressjs.com/api.html#res.sendStatus) instead of `res.send(status)`, `res.status(500).send("...")` instead of `res.send(status, "...")`

- Fixed a small typo (pat -> path)