### PR TITLE
Update jsonwebtoken & express-unless dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "main": "./lib",
   "dependencies": {
     "async": "^0.9.0",
-    "express-unless": "^0.1.0",
-    "jsonwebtoken": "^5.0.0"
+    "express-unless": "^0.3.0",
+    "jsonwebtoken": "^5.0.5"
   },
   "devDependencies": {
     "mocha": "1.x.x"


### PR DESCRIPTION
Updates of jsonwebtoken and express-unless (which is very important) because the last release of express-unless supports excluding routes for specific http methods.