### PR TITLE
Dot-notation support for userProperty/requestProperty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,21 @@ function wrapStaticSecretInCallback(secret){
   };
 }
 
+function deepSet(object, path, value){
+  var a = path.split('.');
+  var o = object;
+  for (var i = 0; i < a.length - 1; i++){
+    var n = a[i];
+    if (n in o){
+      o = o[n];
+    } else {
+      o[n] = {};
+      o = o[n];
+    }
+  }
+  o[a[a.length - 1]] = value;
+}
+
 module.exports = function(options) {
   if (!options || !options.secret) throw new Error('secret should be set');
 
@@ -108,7 +123,7 @@ module.exports = function(options) {
       jwt.verify(token, secret, options, function(err, decoded) {
         if (err && credentialsRequired) return next(new UnauthorizedError('invalid_token', err));
 
-        req[_requestProperty] = decoded;
+        deepSet(req, _requestProperty, decoded);
         next();
       });
     });


### PR DESCRIPTION
Example:
```
  jwt({
    ...
    requestProperty: 'auth.token'
    ...
  });
```

will store the token into `req.auth.token` (creating 'auth' object if it doesn't exist).