### PR TITLE
Updated package.json. async ^1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.0",
     "express-unless": "^0.3.0",
     "jsonwebtoken": "^5.0.0",
     "lodash": "~3.10.1"


### PR DESCRIPTION
Hi, 
We recently updated express-jwt in our platform and we had some issues with the latest version in conjunction with our test suite (in particular mochajs and supertest). 

After some digging we realized the issue was inside the async library. In particular when inside the ```async.waterfall``` the ```async.setImmediate``` method is called. 

We found this issue https://github.com/caolan/async/issues/696. 

So, we decided to update async to the latest version and give it a try. Everything worked again. 