### PR TITLE
More lightweight dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var jwt = require('jsonwebtoken');
 var UnauthorizedError = require('./errors/UnauthorizedError');
 var unless = require('express-unless');
 var async = require('async');
-var _ = require('lodash');
+var set = require('lodash.set');
 
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); }
 
@@ -118,7 +118,7 @@ module.exports = function(options) {
 
     ], function (err, result){
       if (err) { return next(err); }
-      _.set(req, _requestProperty, result);
+      set(req, _requestProperty, result);
       next();
     });
   };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async": "^0.9.0",
     "express-unless": "^0.3.0",
     "jsonwebtoken": "^5.0.0",
-    "lodash": "~3.10.1"
+    "lodash.set": "^4.0.0"
   },
   "devDependencies": {
     "mocha": "1.x.x"


### PR DESCRIPTION
Hey guys

I noticed you were using the entire lodash library and are only using a single function.
So I propose we use the `lodash.set` module, which is an officially lodash maintained NPM package.
(https://www.npmjs.com/package/lodash.set)

I've also contemplated just upgrading the whole lodash package to `^4.2.1`, that way this package can use an existing project's lodash `4.x.x` package since they flattened the node_modules structure in one of the npm versions.

Let me know what you think!