### PR TITLE
disable stack trace from response

### DIFF
--- a/lib/errors/UnauthorizedError.js
+++ b/lib/errors/UnauthorizedError.js
@@ -1,6 +1,6 @@
-function UnauthorizedError (code, error) {
+function UnauthorizedError (code, error, opts) {
   Error.call(this, error.message);
-  Error.captureStackTrace(this, this.constructor);
+  if(opts.stack) Error.captureStackTrace(this, this.constructor)
   this.name = "UnauthorizedError";
   this.message = error.message;
   this.code = code;

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,12 @@ function wrapStaticSecretInCallback(secret){
 module.exports = function(options) {
   if (!options || !options.secret) throw new Error('secret should be set');
 
+  if(!options.error){
+    options.error = {
+      stack: true
+    }
+  }
+
   var secretCallback = options.secret;
 
   if (!isFunction(secretCallback)){
@@ -39,7 +45,6 @@ module.exports = function(options) {
                                     .split(',').map(function (header) {
                                       return header.trim();
                                     }).indexOf('authorization');
-
       if (hasAuthInAccessControl) {
         return next();
       }
@@ -68,16 +73,16 @@ module.exports = function(options) {
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         } else {
-          return next(new UnauthorizedError('credentials_bad_scheme', { message: 'Format is Authorization: Bearer [token]' }));
+          return next(new UnauthorizedError('credentials_bad_scheme', { message: 'Format is Authorization: Bearer [token]' }, options.error ));
         }
       } else {
-        return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));
+        return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }, options.error));
       }
     }
 
     if (!token) {
       if (credentialsRequired) {
-        return next(new UnauthorizedError('credentials_required', { message: 'No authorization token was found' }));
+        return next(new UnauthorizedError('credentials_required', { message: 'No authorization token was found' }, options.error));
       } else {
         return next();
       }
@@ -109,7 +114,7 @@ module.exports = function(options) {
             callback(err);
           }
           else if (revoked) {
-            callback(new UnauthorizedError('revoked_token', {message: 'The token has been revoked.'}));
+            callback(new UnauthorizedError('revoked_token', {message: 'The token has been revoked.'}, options.error));
           } else {
             callback(null, decoded);
           }


### PR DESCRIPTION
added possibility to disable the stack trace from the options, like this:

````
app.use(jwt({
  secret: 'hello world !',
  credentialsRequired: false,
  getToken: function fromHeaderOrQuerystring (req) {
    if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
        return req.headers.authorization.split(' ')[1];
    } else if (req.query && req.query.token) {
      return req.query.token;
    }
    return null;
  },
 error:{
    stack: false
  }
}));
`````