### PR TITLE
Add option to force throw on expired tokens even when credentials are not required

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ module.exports = function(options) {
       },
       function verifyToken(secret, callback) {
         jwt.verify(token, secret, options, function(err, decoded) {
-          if (err && credentialsRequired) {
+          if (err) {
             callback(new UnauthorizedError('invalid_token', err));
           } else {
             callback(null, decoded);

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -159,6 +159,32 @@ describe('failure tests', function () {
       });
   });
 
+  it('should throw error if token is expired even with when credentials are not required', function() {
+      var secret = 'shhhhhh';
+      var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
+
+      req.headers = {};
+      req.headers.authorization = 'Bearer ' + token;
+      expressjwt({ secret: secret, credentialsRequired: false })(req, res, function(err) {
+          assert.ok(err);
+          assert.equal(err.code, 'invalid_token');
+          assert.equal(err.message, 'jwt expired');
+      });
+  });
+
+  it('should throw error if token is invalid even with when credentials are not required', function() {
+      var secret = 'shhhhhh';
+      var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
+
+      req.headers = {};
+      req.headers.authorization = 'Bearer ' + token;
+      expressjwt({ secret: "not the secret", credentialsRequired: false })(req, res, function(err) {
+          assert.ok(err);
+          assert.equal(err.code, 'invalid_token');
+          assert.equal(err.message, 'invalid signature');
+      });
+  });
+
 });
 
 describe('work tests', function () {
@@ -213,18 +239,6 @@ describe('work tests', function () {
     req = {};
     expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function(err) {
       assert(typeof err === 'undefined');
-    });
-  });
-
-  it('should work if token is expired and credentials are not required', function() {
-    var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
-
-    req.headers = {};
-    req.headers.authorization = 'Bearer ' + token;
-    expressjwt({ secret: secret, credentialsRequired: false })(req, res, function(err) {
-      assert(typeof err === 'undefined');
-      assert(typeof req.user === 'undefined')
     });
   });
 


### PR DESCRIPTION
This is to open the discussion, it's OK to have a property used for bypassing token checks. It turns out to be very useful on our case. 

~~However I think (and it's purely based on our use case) that whenever a token is provided the middleware should fail if the token is no longer valid. I don't see the reason why you will by-pass the token error.~~

~~I understand that this could be a major breaking change, it could be added as an option too.~~

*UPDATE*: Instead of changing the default behavior, I've introduced a new option `alwaysThrowOnExpiredToken` which forces the app to throw an exception on expired tokens even when credentials are not required.