### PR TITLE
UnauthorizedError exports directly from the module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,3 +129,5 @@ module.exports = function(options) {
 
   return middleware;
 };
+
+module.exports.UnauthorizedError = UnauthorizedError;


### PR DESCRIPTION
One step easier for all of us to access UnauthorizedError just like in the other auth0 libraries

``` javascript
require('express-jwt').UnauthorizedError
require('jsonwebtoken').JsonWebTokenError
```
