### PR TITLE
Ensure proper error messages end up in stack trace

### DIFF
--- a/lib/errors/UnauthorizedError.js
+++ b/lib/errors/UnauthorizedError.js
@@ -1,8 +1,8 @@
 function UnauthorizedError (code, error) {
-  Error.call(this, error.message);
-  Error.captureStackTrace(this, this.constructor);
   this.name = "UnauthorizedError";
   this.message = error.message;
+  Error.call(this, error.message);
+  Error.captureStackTrace(this, this.constructor);
   this.code = code;
   this.status = 401;
   this.inner = error;

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -267,6 +267,19 @@ describe('work tests', function () {
     });
   });
 
+  it('should produce a stack trace that includes the failure reason', function() {
+    var req = {};
+    var token = jwt.sign({foo: 'bar'}, 'secretA');
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+
+    expressjwt({secret: 'secretB'})(req, res, function(err) {
+      var index = err.stack.indexOf('UnauthorizedError: invalid signature')
+      assert.equal(index, 0, "Stack trace didn't include 'invalid signature' message.")
+    });
+
+  });
+
   it('should work with a custom getToken function', function() {
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);


### PR DESCRIPTION
express-jwt's stack traces don't include error message.
Using the library I was getting error messages like this:

Error
    at /home/mike/projects/cloned/express-jwt/lib/index.js:101:22
    at /home/mike/projects/cloned/express-jwt/node_modules/jsonwebtoken/index.js:54:18
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)

Error.captureStackTrace uses the type and the message during the
creation of the stack trace. This commit calls Error.captureStackTrace
after setting name and message so that the stack trace includes the
description like so:

UnauthorizedError: invalid signature
    at /home/mike/projects/cloned/express-jwt/lib/index.js:101:22
    at /home/mike/projects/cloned/express-jwt/node_modules/jsonwebtoken/index.js:54:18
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
