### PR TITLE
Add option to attach user object to result

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ By default, the decoded token is attached to `req.user` but can be configured wi
 jwt({ secret: publicKey, requestProperty: 'auth' });
 ```
 
+The token can also be attached to the `result` object with the `resultProperty` option. This option will override any `requestProperty`.
+
+```javascript
+jwt({ secret: publicKey, resultProperty: 'locals.user' });
+```
+
+Both `resultProperty` and `requestProperty` utilize [lodash.set](https://lodash.com/docs/4.17.2#set) and will accept nested property paths.
+
 A custom function for extracting the token from a request can be specified with
 the `getToken` option. This is useful if you need to pass the token through a
 query parameter or a cookie. You can throw an error in this function and it will

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ module.exports = function(options) {
   var isRevokedCallback = options.isRevoked || DEFAULT_REVOKED_FUNCTION;
 
   var _requestProperty = options.userProperty || options.requestProperty || 'user';
+  var _resultProperty = options.resultProperty;
   var credentialsRequired = typeof options.credentialsRequired === 'undefined' ? true : options.credentialsRequired;
 
   var middleware = function(req, res, next) {
@@ -119,7 +120,11 @@ module.exports = function(options) {
 
     ], function (err, result){
       if (err) { return next(err); }
-      set(req, _requestProperty, result);
+      if (_resultProperty) {
+        set(res, _resultProperty, result);
+      } else {
+        set(req, _requestProperty, result);
+      }
       next();
     });
   };

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -253,6 +253,34 @@ describe('work tests', function () {
     });
   });
 
+  it('should set resultProperty if option provided', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req = { };
+    res = { };
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secret, resultProperty: 'locals.user'})(req, res, function() {
+      assert.equal('bar', res.locals.user.foo);
+      assert.ok(typeof req.user === 'undefined');
+    });
+  });
+
+  it('should ignore userProperty if resultProperty option provided', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req = { };
+    res = { };
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secret, userProperty: 'auth', resultProperty: 'locals.user'})(req, res, function() {
+      assert.equal('bar', res.locals.user.foo);
+      assert.ok(typeof req.auth === 'undefined');
+    });
+  });
+
   it('should work if no authorization header and credentials are not required', function() {
     req = {};
     expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function(err) {


### PR DESCRIPTION
According to the Express 4.0 [docs](http://expressjs.com/en/api.html#res.locals), the recommended place to put request scoped data is on `res.locals`.

This pull request adds a `resultProperty` option which when set will override the default `req.user` with the passed in property path on the result object. If both `requestProperty` and `resultProperty` are set, then `requestProperty` is ignored.

```javascript
jwt({ secret: publicKey, resultProperty: 'locals.user' });
```

This change seems sensible to me because it allows support for using `res.locals` while maintaining backwards compatibility.