### PR TITLE
Deprecate `resultProperty` in favor of new `responseProperty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ By default, the decoded token is attached to `req.user` but can be configured wi
 jwt({ secret: publicKey, requestProperty: 'auth' });
 ```
 
-The token can also be attached to the `result` object with the `resultProperty` option. This option will override any `requestProperty`.
+The token can also be attached to the `response` object with the `responseProperty` option. This option will override any `requestProperty`.
 
 ```javascript
-jwt({ secret: publicKey, resultProperty: 'locals.user' });
+jwt({ secret: publicKey, responseProperty: 'locals.user' });
 ```
 
-Both `resultProperty` and `requestProperty` utilize [lodash.set](https://lodash.com/docs/4.17.2#set) and will accept nested property paths.
+*_NOTE_: `resultProperty` has been deprecated in favor of responseProperty.*
+
+Both `responseProperty` and `requestProperty` utilize [lodash.set](https://lodash.com/docs/4.17.2#set) and will accept nested property paths.
 
 A custom function for extracting the token from a request can be specified with
 the `getToken` option. This is useful if you need to pass the token through a

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,14 @@ module.exports = function(options) {
   var isRevokedCallback = options.isRevoked || DEFAULT_REVOKED_FUNCTION;
 
   var _requestProperty = options.userProperty || options.requestProperty || 'user';
-  var _responseProperty = options.requestProperty || options.resultProperty || 'locals.user';
+  
+  // resultProperty has been deprecated in favor of the more clear responseProperty
+  if (options.resultProperty) {
+    console.log('WARN: `resultProperty` has been deprecated in favor of `responseProperty`.')
+    options.responseProperty = options.resultProperty
+  }
+  
+  var _responseProperty = options.responseProperty || 'locals.user';
   var credentialsRequired = typeof options.credentialsRequired === 'undefined' ? true : options.credentialsRequired;
 
   var middleware = function(req, res, next) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ module.exports = function(options) {
   var isRevokedCallback = options.isRevoked || DEFAULT_REVOKED_FUNCTION;
 
   var _requestProperty = options.userProperty || options.requestProperty || 'user';
-  var _resultProperty = options.resultProperty;
+  var _responseProperty = options.requestProperty || options.resultProperty || 'locals.user';
   var credentialsRequired = typeof options.credentialsRequired === 'undefined' ? true : options.credentialsRequired;
 
   var middleware = function(req, res, next) {
@@ -120,8 +120,8 @@ module.exports = function(options) {
 
     ], function (err, result){
       if (err) { return next(err); }
-      if (_resultProperty) {
-        set(res, _resultProperty, result);
+      if (_responseProperty) {
+        set(res, _responseProperty, result);
       } else {
         set(req, _requestProperty, result);
       }

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -253,7 +253,21 @@ describe('work tests', function () {
     });
   });
 
-  it('should set resultProperty if option provided', function() {
+  it('should set responseProperty if option provided', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req = { };
+    res = { };
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secret, responseProperty: 'locals.user'})(req, res, function() {
+      assert.equal('bar', res.locals.user.foo);
+      assert.ok(typeof req.user === 'undefined');
+    });
+  });
+  
+  it('should set responseProperty if resultProperty (deprecated) option provided', function () {
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -267,7 +281,7 @@ describe('work tests', function () {
     });
   });
 
-  it('should ignore userProperty if resultProperty option provided', function() {
+  it('should ignore userProperty if responseProperty option provided', function() {
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -275,7 +289,7 @@ describe('work tests', function () {
     res = { };
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret, userProperty: 'auth', resultProperty: 'locals.user'})(req, res, function() {
+    expressjwt({secret: secret, userProperty: 'auth', responseProperty: 'locals.user'})(req, res, function() {
       assert.equal('bar', res.locals.user.foo);
       assert.ok(typeof req.auth === 'undefined');
     });


### PR DESCRIPTION
# Reason: 
* `resultProperty` is a misnomer and confusing.
* The `res` variable name is shorthand for `response`, not `result`.
* It seems like `result` was used due to being the variable name to hold the `result` argument of the callback to `async.waterfall`.

# Example:

> By default, the decoded token is attached to req.user but can be configured with the requestProperty option.
> 
> jwt({ secret: publicKey, requestProperty: 'auth' });
> The token can also be attached to the result object with the resultProperty option. This option will override any requestProperty.
> 
> jwt({ secret: publicKey, resultProperty: 'locals.user' });

# Proposed solution: 
1) create new option called `responseProperty` that serves the same purpose, but with the new name
2) when `resultProperty` is used, print deprecation warning and assign value to `responseProperty`
3) update the README for clarity.

Questions, comments, complaints, concerns, please! 
Thank you