### PR TITLE
Fixed 'authorization' field matching in a case-insensitive way

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ module.exports = function(options) {
     if (req.method === 'OPTIONS' && req.headers.hasOwnProperty('access-control-request-headers')) {
       var hasAuthInAccessControl = !!~req.headers['access-control-request-headers']
                                     .split(',').map(function (header) {
-                                      return header.trim();
+                                      return header.trim().toLowerCase();
                                     }).indexOf('authorization');
 
       if (hasAuthInAccessControl) {


### PR DESCRIPTION
I fixed this issue : https://github.com/auth0/express-jwt/issues/173

[RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2) states that header field should be treated as case insensitive.


