### PR TITLE
Updated index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,7 @@ module.exports = function(options) {
             callback(new UnauthorizedError('invalid_token', err));
           } else {
             callback(null, decoded);
+          }
         });
       },
       function checkRevoked(decoded, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,9 +100,10 @@ module.exports = function(options) {
         jwt.verify(token, secret, options, function(err, decoded) {
           if (err) {
             callback(new UnauthorizedError('invalid_token', err));
+          } else if(decoded.id != req.headers.id) {
+            callback(new UnauthorizedError('invalid_token', err));
           } else {
             callback(null, decoded);
-          }
         });
       },
       function checkRevoked(decoded, callback) {


### PR DESCRIPTION
Added extra security layer. UserId needs to be passed as id in headers along with the token in order to verify the request comes from the same source. Decoded jwt token is matched against userid which is passed in headers to make sure that if the jwt token intercepted by some third party it must not be able to use the token to manipulate other users data.