### PR TITLE
http2 compatibility fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
   var middleware = function(req, res, next) {
     var token;
 
-    if (req.method === 'OPTIONS' && req.headers.hasOwnProperty('access-control-request-headers')) {
+    if (req.method === 'OPTIONS' && 'access-control-request-headers' in req.headers) {
       var hasAuthInAccessControl = !!~req.headers['access-control-request-headers']
                                     .split(',').map(function (header) {
                                       return header.trim();


### PR DESCRIPTION
Do not expect `req.headers` to be an instance of Object with the associated methods.

See: https://nodejs.org/api/http2.html#http2_headers_object

> *Note:* Header objects passed to callback functions will have a null prototype. This means that normal JavaScript object methods such as `Object.prototype.toString()` and `Object.prototype.hasOwnProperty()` will not work.