### PR TITLE
token expired callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ module.exports = function(options) {
     secretCallback = wrapStaticSecretInCallback(secretCallback);
   }
 
+  var isExpiredCallback = options.isExpired;
   var isRevokedCallback = options.isRevoked || DEFAULT_REVOKED_FUNCTION;
 
   var _requestProperty = options.userProperty || options.requestProperty || 'user';
@@ -99,7 +100,19 @@ module.exports = function(options) {
       function verifyToken(secret, callback) {
         jwt.verify(token, secret, options, function(err, decoded) {
           if (err) {
-            callback(new UnauthorizedError('invalid_token', err));
+            if (err.message === 'jwt expired' && isFunction(isExpiredCallback)) {
+                set(req, _requestProperty, dtoken.payload);
+                isExpiredCallback(err, req, function (err) {
+                    if (err) {
+                        callback(new UnauthorizedError('invalid_token', err));
+                    } else {
+                        _decoded = jwt.decode(token);
+                        callback(null, _decoded)
+                    }
+                });
+            } else {
+                callback(new UnauthorizedError('invalid_token', err));
+            }
           } else {
             callback(null, decoded);
           }


### PR DESCRIPTION
I created a callback in the case of an expired token, with the token decoding itself

```javascript
router.use(
    jwt({secret: 'ssshhhh', isExpired: (err, req, next) => {
        // check conditions
        if (req.user.uid == null) {
            return next(err);
        }

        // TODO: ...
        return next();
    }}),
    (req, res, next) => {
      // TODO: ...
});
```