### PR TITLE
Add handling for lambda environment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,8 +51,11 @@ module.exports = function(options) {
       } catch (e) {
         return next(e);
       }
-    } else if (req.headers && req.headers.authorization) {
-      var parts = req.headers.authorization.split(' ');
+    } else if (req.headers && (req.headers.authorization || req.headers.Authorization)) {
+      var parts = req.headers.authorization ?
+        req.headers.authorization.split(' '):
+        req.headers.Authorization.split(' ');
+
       if (parts.length == 2) {
         var scheme = parts[0];
         var credentials = parts[1];


### PR DESCRIPTION
Express and all Node.js frameworks auto normalize the headers but there is one environment which does not do it. AWS lambda does not normalize the headers. In order to normalize them usage of 3rd party library is needed. That's why I added the handling of `Authorization` header.

Please let me know whether the tests for that feature are necessary.