### PR TITLE
Add header in the README secretCallback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ var jwt = require('express-jwt');
 var data = require('./data');
 var utilities = require('./utilities');
 
-var secretCallback = function(req, payload, done){
+var secretCallback = function(req, header, payload, done){
   var issuer = payload.iss;
 
   data.getTenantByIdentifier(issuer, function(err, tenant){


### PR DESCRIPTION
Helps people who are using RS256 with KIDs (e.g. https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third_party_jwt_library) to more immediately see what's going on.