### PR TITLE
Check token issuer before getting secret

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,16 @@ module.exports = function(options) {
       return next(new UnauthorizedError('invalid_token', err));
     }
 
+    // Although `jwt.verify` will do this check for us, we do this early to
+    // prevent unnecessary calls to `secretCallback`.
+    if (options.issuer && dtoken.payload && dtoken.payload.iss !== options.issuer) {
+      return next(
+        new UnauthorizedError('invalid_token',
+          new jwt.JsonWebTokenError('jwt issuer invalid. expected: ' + options.issuer)
+        )
+      );
+    }
+
     async.waterfall([
       function getSecret(callback){
         var arity = secretCallback.length;


### PR DESCRIPTION
In production, we ran into an issue where if an express server starts up and a client attempts to make requests with an access token issued from the wrong issuer, this may lead to a denial of service.

Our simplified usage is illustrated as follows:

```ts
import * as jwt from "express-jwt";
import * as jwksRsa from "jwks-rsa";

//...

const checkJwt = jwt({
  // Dynamically provide a signing key based on the `kid` in the header and the
  // signing keys provided by the JWKS endpoint.
  secret: jwksRsa.expressJwtSecret({
    cache: true,
    rateLimit: true,
    jwksRequestsPerMinute: 5,
    jwksUri: `${AUTH0_URL}/.well-known/jwks.json`,
  }),

  // Validate the audience and the issuer.
  audience: "our-audience",
  issuer: `${AUTH0_URL}/`,
  algorithms: ["RS256"],
});

// ...

app.get("/endpoint", [checkJwt], ourRoute);
```

The DOS occurs when a client is hitting the endpoint with an access token from the wrong issuer when the server starts up. Due to the way `jwksRsa.expressJwtSecret` behaves with `rateLimit` set to `true`, this causes a JWKS rate limiting error thrown to protect the certificate endpoint from getting rate limited. Thus, when the rate limit imposed by ` jwksRsa.expressJwtSecret` is reached valid access tokens from other clients are rejected.

This PR addresses the issue by checking if the issuer is valid before attempting to call the secret callback, and thus avoiding the rate limiting issue.