### PR TITLE
Changed the isFunction check to be ok with async #202

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var set = require('lodash.set');
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); };
 
 function isFunction(object) {
-  return Object.prototype.toString.call(object) === '[object Function]';
+  return !!(object && object.constructor && object.call && object.apply);
 }
 
 function wrapStaticSecretInCallback(secret){

--- a/test/multitenancy.test.js
+++ b/test/multitenancy.test.js
@@ -39,6 +39,21 @@ describe('multitenancy', function(){
     });
   });
 
+  it ('should retrieve secret using async callback', function(done){
+    var token = jwt.sign({ iss: 'a', foo: 'bar'}, tenants.a.secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({
+      secret: async (req, header, payload, cb) => {
+        return cb(null, tenants[payload.iss].secret);
+      }
+    })(req, res, function() {
+      assert.equal('bar', req.user.foo);
+      done();
+    });
+  });
+
   it ('should throw if an error ocurred when retrieving the token', function(){
     var secret = 'shhhhhh';
     var token = jwt.sign({ iss: 'inexistent', foo: 'bar'}, secret);


### PR DESCRIPTION
### Description

Changed the `isFunction` method so that it detects async functions. This resolves #202.

### References

Theres a big discussion on detecting function types on stack overflow (https://stackoverflow.com/a/6000009/1070291). The preferred method is to use `typeof`. The main reason against using this is the performance of a string comparison. Given this isnt in a tight loop, and we are doing other way more expensive things (like checking signatures) this performance difference isn't worth the increased complexity.

### Testing

Ive added a new unit test which uses an async method.
