### PR TITLE
Added sane default values for signing algoritms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ var publicKey = fs.readFileSync('/path/to/public.pub');
 jwt({ secret: publicKey });
 ```
 
+#### Enabling "none" signature
+
+By default, empty (none) signatures are not allowed, enable it by supplying it in the `algorithms` option.
+
+```javascript
+jwt({ secret: publicKey, algorithms: ["HS256", "none"] });
+```
+
 ### Retrieving the Decoded Payload
 
 By default, the decoded token is attached to `req.user` but can be configured with the `requestProperty` option.

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,16 @@ module.exports = function(options) {
         }
       },
       function verifyToken(secret, callback) {
-        jwt.verify(token, secret, options, function(err, decoded) {
+        // Default the allowed signing algorithms to all execpt none. 
+        var verifyOptions = Object.assign({
+          algorithms: [
+            "HS256", "HS384", "HS512",
+            "RS256", "RS384", "RS512",
+            "ES256", "ES384", "ES512",
+            "PS256", "PS384", "PS512",
+          ]
+        }, options)
+        jwt.verify(token, secret, verifyOptions, function(err, decoded) {
           if (err) {
             callback(new UnauthorizedError('invalid_token', err));
           } else {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -5,9 +5,6 @@ var expressjwt = require('../lib');
 var UnauthorizedError = require('../lib/errors/UnauthorizedError');
 
 describe('failure tests', function () {
-  var req = {};
-  var res = {};
-
   it('should throw if options not sent', function() {
     try {
       expressjwt();
@@ -43,6 +40,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if authorization header is malformed', function() {
+    var req = {};
     req.headers = {};
     req.headers.authorization = 'wrong';
     expressjwt({secret: 'shhhh'})(req, res, function(err) {
@@ -52,6 +50,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if authorization header is not Bearer', function() {
+    var req = {};
     req.headers = {};
     req.headers.authorization = 'Basic foobar';
     expressjwt({secret: 'shhhh'})(req, res, function(err) {
@@ -61,6 +60,7 @@ describe('failure tests', function () {
   });
 
   it('should next if authorization header is not Bearer and credentialsRequired is false', function() {
+    var req = {};
     req.headers = {};
     req.headers.authorization = 'Basic foobar';
     expressjwt({secret: 'shhhh', credentialsRequired: false})(req, res, function(err) {
@@ -69,6 +69,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if authorization header is not well-formatted jwt', function() {
+    var req = {};
     req.headers = {};
     req.headers.authorization = 'Bearer wrongjwt';
     expressjwt({secret: 'shhhh'})(req, res, function(err) {
@@ -78,6 +79,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if jwt is an invalid json', function() {
+    var req = {};
     req.headers = {};
     req.headers.authorization = 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.yJ1c2VybmFtZSI6InNhZ3VpYXIiLCJpYXQiOjE0NzEwMTg2MzUsImV4cCI6MTQ3MzYxMDYzNX0.foo';
     expressjwt({secret: 'shhhh'})(req, res, function(err) {
@@ -87,6 +89,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if authorization header is not valid jwt', function() {
+    var req = {};
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -100,6 +103,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if audience is not expected', function() {
+    var req = {};
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar', aud: 'expected-audience'}, secret);
 
@@ -113,6 +117,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if token is expired', function() {
+    var req = {};
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar', exp: 1382412921 }, secret);
 
@@ -127,6 +132,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if token issuer is wrong', function() {
+    var req = {};
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
@@ -140,8 +146,8 @@ describe('failure tests', function () {
   });
 
   it('should use errors thrown from custom getToken function', function() {
+    var req = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
 
     function getTokenThatThrowsError() {
       throw new UnauthorizedError('invalid_token', { message: 'Invalid token!' });
@@ -159,6 +165,7 @@ describe('failure tests', function () {
 
 
   it('should throw error when signature is wrong', function() {
+      var req = {};
       var secret = "shhh";
       var token = jwt.sign({foo: 'bar', iss: 'http://www'}, secret);
       // manipulate the token
@@ -178,6 +185,7 @@ describe('failure tests', function () {
   });
 
   it('should throw error if token is expired even with when credentials are not required', function() {
+      var req = {};
       var secret = 'shhhhhh';
       var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
 
@@ -191,6 +199,7 @@ describe('failure tests', function () {
   });
 
   it('should throw error if token is invalid even with when credentials are not required', function() {
+      var req = {};
       var secret = 'shhhhhh';
       var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
 
@@ -203,13 +212,27 @@ describe('failure tests', function () {
       });
   });
 
+  it('should throw error if the jwt is unsigned and not explicitly allowed with algorithms:[none]', function(done) {
+    var req = {};
+    var secretCallback = function(req, headers, payload, cb) {
+      process.nextTick(function(){ return cb(null, null) });
+    }
+    var token = jwt.sign({foo: 'bar'}, 'secret', {algorithm: "none"});
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secretCallback})(req, res, function(err) {
+      assert.ok(err);
+      assert.equal(err.code, 'invalid_token');
+      assert.equal(err.message, 'invalid algorithm');
+      done();
+    });
+  });
 });
 
 describe('work tests', function () {
-  var req = {};
-  var res = {};
-
   it('should work if authorization header is valid jwt', function() {
+    var req = { };
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -221,6 +244,7 @@ describe('work tests', function () {
   });
 
   it('should work with nested properties', function() {
+    var req = { };
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -232,6 +256,7 @@ describe('work tests', function () {
   });
 
   it('should work if authorization header is valid with a buffer secret', function() {
+    var req = { };
     var secret = new Buffer('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'base64');
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -243,6 +268,7 @@ describe('work tests', function () {
   });
 
   it('should set userProperty if option provided', function() {
+    var req = { };
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -254,11 +280,10 @@ describe('work tests', function () {
   });
 
   it('should set resultProperty if option provided', function() {
+    var req = { };
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
-    req = { };
-    res = { };
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
     expressjwt({secret: secret, resultProperty: 'locals.user'})(req, res, function() {
@@ -268,11 +293,10 @@ describe('work tests', function () {
   });
 
   it('should ignore userProperty if resultProperty option provided', function() {
+    var req = { };
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
-    req = { };
-    res = { };
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
     expressjwt({secret: secret, userProperty: 'auth', resultProperty: 'locals.user'})(req, res, function() {
@@ -282,14 +306,15 @@ describe('work tests', function () {
   });
 
   it('should work if no authorization header and credentials are not required', function() {
-    req = {};
+    var req = { };
     expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function(err) {
       assert(typeof err === 'undefined');
-    });
+    })
   });
 
   it('should not work if no authorization header', function() {
-    req = {};
+    var req = { };
+
     expressjwt({ secret: 'shhhh' })(req, res, function(err) {
       assert(typeof err !== 'undefined');
     });
@@ -309,6 +334,7 @@ describe('work tests', function () {
   });
 
   it('should work with a custom getToken function', function() {
+    var req = {};
     var secret = 'shhhhhh';
     var token = jwt.sign({foo: 'bar'}, secret);
 
@@ -328,7 +354,8 @@ describe('work tests', function () {
     });
   });
 
-  it('should work with a secretCallback function that accepts header argument', function() {
+  it('should work with a secretCallback function that accepts header argument', function(done) {
+    var req = {};
     var secret = 'shhhhhh';
     var secretCallback = function(req, headers, payload, cb) {
       assert.equal(headers.alg, 'HS256');
@@ -341,6 +368,21 @@ describe('work tests', function () {
     req.headers.authorization = 'Bearer ' + token;
     expressjwt({secret: secretCallback})(req, res, function() {
       assert.equal('bar', req.user.foo);
+      done()
+    });
+  });
+  it('should work with unsigned jwts when explicitly allowed with algorithms:[none]', function(done) {
+    var req = {};
+    var secretCallback = function(req, headers, payload, cb) {
+      process.nextTick(function(){ return cb(null, null) });
+    }
+    var token = jwt.sign({foo: 'bar'}, 'secret', {algorithm: "none"});
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({secret: secretCallback, algorithms: ["none"]})(req, res, function() {
+      assert.equal('bar', req.user.foo);
+      done();
     });
   });
 });

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -5,125 +5,138 @@ var expressjwt = require('../lib');
 var UnauthorizedError = require('../lib/errors/UnauthorizedError');
 
 describe('failure tests', function () {
-  it('should throw if options not sent', function() {
+  it('should throw if options not sent', function () {
     try {
       expressjwt();
-    } catch(e) {
+    } catch (e) {
       assert.ok(e);
       assert.equal(e.message, 'secret should be set');
     }
   });
 
-  it('should throw if no authorization header and credentials are required', function() {
-    expressjwt({secret: 'shhhh', credentialsRequired: true})(req, res, function(err) {
+  it('should throw if no authorization header and credentials are required', function () {
+    var req = {};
+    var res = {};
+    expressjwt({ secret: 'shhhh', credentialsRequired: true })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'credentials_required');
     });
   });
 
-  it('support unless skip', function() {
+  it('support unless skip', function () {
+    var req = {};
+    var res = {};
     req.originalUrl = '/index.html';
-    expressjwt({secret: 'shhhh'}).unless({path: '/index.html'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhh' }).unless({ path: '/index.html' })(req, res, function (err) {
       assert.ok(!err);
     });
   });
 
-  it('should skip on CORS preflight', function() {
+  it('should skip on CORS preflight', function () {
     var corsReq = {};
+    var res = {};
     corsReq.method = 'OPTIONS';
     corsReq.headers = {
       'access-control-request-headers': 'sasa, sras,  authorization'
     };
-    expressjwt({secret: 'shhhh'})(corsReq, res, function(err) {
+    expressjwt({ secret: 'shhhh' })(corsReq, res, function (err) {
       assert.ok(!err);
     });
   });
 
-  it('should throw if authorization header is malformed', function() {
+  it('should throw if authorization header is malformed', function () {
     var req = {};
+    var res = {};
     req.headers = {};
     req.headers.authorization = 'wrong';
-    expressjwt({secret: 'shhhh'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhh' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'credentials_bad_format');
     });
   });
 
-  it('should throw if authorization header is not Bearer', function() {
+  it('should throw if authorization header is not Bearer', function () {
     var req = {};
+    var res = {};
     req.headers = {};
     req.headers.authorization = 'Basic foobar';
-    expressjwt({secret: 'shhhh'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhh' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'credentials_bad_scheme');
     });
   });
 
-  it('should next if authorization header is not Bearer and credentialsRequired is false', function() {
+  it('should next if authorization header is not Bearer and credentialsRequired is false', function () {
     var req = {};
+    var res = {};
     req.headers = {};
     req.headers.authorization = 'Basic foobar';
-    expressjwt({secret: 'shhhh', credentialsRequired: false})(req, res, function(err) {
+    expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function (err) {
       assert.ok(typeof err === 'undefined');
     });
   });
 
-  it('should throw if authorization header is not well-formatted jwt', function() {
+  it('should throw if authorization header is not well-formatted jwt', function () {
     var req = {};
+    var res = {};
     req.headers = {};
     req.headers.authorization = 'Bearer wrongjwt';
-    expressjwt({secret: 'shhhh'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhh' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
     });
   });
 
-  it('should throw if jwt is an invalid json', function() {
+  it('should throw if jwt is an invalid json', function () {
     var req = {};
+    var res = {};
     req.headers = {};
     req.headers.authorization = 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.yJ1c2VybmFtZSI6InNhZ3VpYXIiLCJpYXQiOjE0NzEwMTg2MzUsImV4cCI6MTQ3MzYxMDYzNX0.foo';
-    expressjwt({secret: 'shhhh'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhh' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
     });
   });
 
-  it('should throw if authorization header is not valid jwt', function() {
+  it('should throw if authorization header is not valid jwt', function () {
     var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: 'different-shhhh'})(req, res, function(err) {
+    expressjwt({ secret: 'different-shhhh' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
       assert.equal(err.message, 'invalid signature');
     });
   });
 
-  it('should throw if audience is not expected', function() {
+  it('should throw if audience is not expected', function () {
     var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', aud: 'expected-audience'}, secret);
+    var token = jwt.sign({ foo: 'bar', aud: 'expected-audience' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: 'shhhhhh', audience: 'not-expected-audience'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhhhh', audience: 'not-expected-audience' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
       assert.equal(err.message, 'jwt audience invalid. expected: not-expected-audience');
     });
   });
 
-  it('should throw if token is expired', function() {
+  it('should throw if token is expired', function () {
     var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', exp: 1382412921 }, secret);
+    var token = jwt.sign({ foo: 'bar', exp: 1382412921 }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: 'shhhhhh'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhhhh' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
       assert.equal(err.inner.name, 'TokenExpiredError');
@@ -131,23 +144,24 @@ describe('failure tests', function () {
     });
   });
 
-  it('should throw if token issuer is wrong', function() {
+  it('should throw if token issuer is wrong', function () {
     var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = jwt.sign({ foo: 'bar', iss: 'http://foo' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: 'shhhhhh', issuer: 'http://wrong'})(req, res, function(err) {
+    expressjwt({ secret: 'shhhhhh', issuer: 'http://wrong' })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
       assert.equal(err.message, 'jwt issuer invalid. expected: http://wrong');
     });
   });
 
-  it('should use errors thrown from custom getToken function', function() {
+  it('should use errors thrown from custom getToken function', function () {
     var req = {};
-    var secret = 'shhhhhh';
+    var res = {};
 
     function getTokenThatThrowsError() {
       throw new UnauthorizedError('invalid_token', { message: 'Invalid token!' });
@@ -156,7 +170,7 @@ describe('failure tests', function () {
     expressjwt({
       secret: 'shhhhhh',
       getToken: getTokenThatThrowsError
-    })(req, res, function(err) {
+    })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
       assert.equal(err.message, 'Invalid token!');
@@ -164,64 +178,68 @@ describe('failure tests', function () {
   });
 
 
-  it('should throw error when signature is wrong', function() {
-      var req = {};
-      var secret = "shhh";
-      var token = jwt.sign({foo: 'bar', iss: 'http://www'}, secret);
-      // manipulate the token
-      var newContent = new Buffer("{foo: 'bar', edg: 'ar'}").toString('base64');
-      var splitetToken = token.split(".");
-      splitetToken[1] = newContent;
-      var newToken = splitetToken.join(".");
-
-      // build request
-      req.headers = [];
-      req.headers.authorization = 'Bearer ' + newToken;
-      expressjwt({secret: secret})(req,res, function(err) {
-          assert.ok(err);
-          assert.equal(err.code, 'invalid_token');
-          assert.equal(err.message, 'invalid token');
-      });
-  });
-
-  it('should throw error if token is expired even with when credentials are not required', function() {
-      var req = {};
-      var secret = 'shhhhhh';
-      var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
-
-      req.headers = {};
-      req.headers.authorization = 'Bearer ' + token;
-      expressjwt({ secret: secret, credentialsRequired: false })(req, res, function(err) {
-          assert.ok(err);
-          assert.equal(err.code, 'invalid_token');
-          assert.equal(err.message, 'jwt expired');
-      });
-  });
-
-  it('should throw error if token is invalid even with when credentials are not required', function() {
-      var req = {};
-      var secret = 'shhhhhh';
-      var token = jwt.sign({foo: 'bar', exp: 1382412921}, secret);
-
-      req.headers = {};
-      req.headers.authorization = 'Bearer ' + token;
-      expressjwt({ secret: "not the secret", credentialsRequired: false })(req, res, function(err) {
-          assert.ok(err);
-          assert.equal(err.code, 'invalid_token');
-          assert.equal(err.message, 'invalid signature');
-      });
-  });
-
-  it('should throw error if the jwt is unsigned and not explicitly allowed with algorithms:[none]', function(done) {
+  it('should throw error when signature is wrong', function () {
     var req = {};
-    var secretCallback = function(req, headers, payload, cb) {
-      process.nextTick(function(){ return cb(null, null) });
-    }
-    var token = jwt.sign({foo: 'bar'}, 'secret', {algorithm: "none"});
+    var res = {};
+    var secret = "shhh";
+    var token = jwt.sign({ foo: 'bar', iss: 'http://www' }, secret);
+    // manipulate the token
+    var newContent = new Buffer("{foo: 'bar', edg: 'ar'}").toString('base64');
+    var splitetToken = token.split(".");
+    splitetToken[1] = newContent;
+    var newToken = splitetToken.join(".");
+
+    // build request
+    req.headers = [];
+    req.headers.authorization = 'Bearer ' + newToken;
+    expressjwt({ secret: secret })(req, res, function (err) {
+      assert.ok(err);
+      assert.equal(err.code, 'invalid_token');
+      assert.equal(err.message, 'invalid token');
+    });
+  });
+
+  it('should throw error if token is expired even with when credentials are not required', function () {
+    var req = {};
+    var res = {};
+    var secret = 'shhhhhh';
+    var token = jwt.sign({ foo: 'bar', exp: 1382412921 }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secretCallback})(req, res, function(err) {
+    expressjwt({ secret: secret, credentialsRequired: false })(req, res, function (err) {
+      assert.ok(err);
+      assert.equal(err.code, 'invalid_token');
+      assert.equal(err.message, 'jwt expired');
+    });
+  });
+
+  it('should throw error if token is invalid even with when credentials are not required', function () {
+    var req = {};
+    var res = {};
+    var secret = 'shhhhhh';
+    var token = jwt.sign({ foo: 'bar', exp: 1382412921 }, secret);
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({ secret: "not the secret", credentialsRequired: false })(req, res, function (err) {
+      assert.ok(err);
+      assert.equal(err.code, 'invalid_token');
+      assert.equal(err.message, 'invalid signature');
+    });
+  });
+
+  it('should throw error if the jwt is unsigned and not explicitly allowed with algorithms:[none]', function (done) {
+    var req = {};
+    var res = {};
+    var secretCallback = function (req, headers, payload, cb) {
+      process.nextTick(function () { return cb(null, null) });
+    }
+    var token = jwt.sign({ foo: 'bar' }, 'secret', { algorithm: "none" });
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    expressjwt({ secret: secretCallback })(req, res, function (err) {
       assert.ok(err);
       assert.equal(err.code, 'invalid_token');
       assert.equal(err.message, 'invalid algorithm');
@@ -231,112 +249,121 @@ describe('failure tests', function () {
 });
 
 describe('work tests', function () {
-  it('should work if authorization header is valid jwt', function() {
-    var req = { };
+  it('should work if authorization header is valid jwt', function () {
+    var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret})(req, res, function() {
+    expressjwt({ secret: secret })(req, res, function () {
       assert.equal('bar', req.user.foo);
     });
   });
 
-  it('should work with nested properties', function() {
-    var req = { };
+  it('should work with nested properties', function () {
+    var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret, requestProperty: 'auth.token'})(req, res, function() {
+    expressjwt({ secret: secret, requestProperty: 'auth.token' })(req, res, function () {
       assert.equal('bar', req.auth.token.foo);
     });
   });
 
-  it('should work if authorization header is valid with a buffer secret', function() {
-    var req = { };
+  it('should work if authorization header is valid with a buffer secret', function () {
+    var req = {};
+    var res = {};
     var secret = new Buffer('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'base64');
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret})(req, res, function() {
+    expressjwt({ secret: secret })(req, res, function () {
       assert.equal('bar', req.user.foo);
     });
   });
 
-  it('should set userProperty if option provided', function() {
-    var req = { };
+  it('should set userProperty if option provided', function () {
+    var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret, userProperty: 'auth'})(req, res, function() {
+    expressjwt({ secret: secret, userProperty: 'auth' })(req, res, function () {
       assert.equal('bar', req.auth.foo);
     });
   });
 
-  it('should set resultProperty if option provided', function() {
-    var req = { };
+  it('should set resultProperty if option provided', function () {
+    var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret, resultProperty: 'locals.user'})(req, res, function() {
+    expressjwt({ secret: secret, resultProperty: 'locals.user' })(req, res, function () {
       assert.equal('bar', res.locals.user.foo);
       assert.ok(typeof req.user === 'undefined');
     });
   });
 
-  it('should ignore userProperty if resultProperty option provided', function() {
-    var req = { };
+  it('should ignore userProperty if resultProperty option provided', function () {
+    var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secret, userProperty: 'auth', resultProperty: 'locals.user'})(req, res, function() {
+    expressjwt({ secret: secret, userProperty: 'auth', resultProperty: 'locals.user' })(req, res, function () {
       assert.equal('bar', res.locals.user.foo);
       assert.ok(typeof req.auth === 'undefined');
     });
   });
 
-  it('should work if no authorization header and credentials are not required', function() {
-    var req = { };
-    expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function(err) {
+  it('should work if no authorization header and credentials are not required', function () {
+    var req = {};
+    var res = {};
+    expressjwt({ secret: 'shhhh', credentialsRequired: false })(req, res, function (err) {
       assert(typeof err === 'undefined');
     })
   });
 
-  it('should not work if no authorization header', function() {
-    var req = { };
-
-    expressjwt({ secret: 'shhhh' })(req, res, function(err) {
+  it('should not work if no authorization header', function () {
+    var req = {};
+    var res = {};
+    expressjwt({ secret: 'shhhh' })(req, res, function (err) {
       assert(typeof err !== 'undefined');
     });
   });
 
-  it('should produce a stack trace that includes the failure reason', function() {
+  it('should produce a stack trace that includes the failure reason', function () {
     var req = {};
-    var token = jwt.sign({foo: 'bar'}, 'secretA');
+    var res = {};
+    var token = jwt.sign({ foo: 'bar' }, 'secretA');
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
 
-    expressjwt({secret: 'secretB'})(req, res, function(err) {
+    expressjwt({ secret: 'secretB' })(req, res, function (err) {
       var index = err.stack.indexOf('UnauthorizedError: invalid signature')
       assert.equal(index, 0, "Stack trace didn't include 'invalid signature' message.")
     });
 
   });
 
-  it('should work with a custom getToken function', function() {
+  it('should work with a custom getToken function', function () {
     var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.query = {};
@@ -349,38 +376,40 @@ describe('work tests', function () {
     expressjwt({
       secret: secret,
       getToken: getTokenFromQuery
-    })(req, res, function() {
+    })(req, res, function () {
       assert.equal('bar', req.user.foo);
     });
   });
 
-  it('should work with a secretCallback function that accepts header argument', function(done) {
+  it('should work with a secretCallback function that accepts header argument', function (done) {
     var req = {};
+    var res = {};
     var secret = 'shhhhhh';
-    var secretCallback = function(req, headers, payload, cb) {
+    var secretCallback = function (req, headers, payload, cb) {
       assert.equal(headers.alg, 'HS256');
       assert.equal(payload.foo, 'bar');
-      process.nextTick(function(){ return cb(null, secret) });
+      process.nextTick(function () { return cb(null, secret) });
     }
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({ foo: 'bar' }, secret);
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secretCallback})(req, res, function() {
+    expressjwt({ secret: secretCallback })(req, res, function () {
       assert.equal('bar', req.user.foo);
       done()
     });
   });
-  it('should work with unsigned jwts when explicitly allowed with algorithms:[none]', function(done) {
+  it('should work with unsigned jwts when explicitly allowed with algorithms:[none]', function (done) {
     var req = {};
-    var secretCallback = function(req, headers, payload, cb) {
-      process.nextTick(function(){ return cb(null, null) });
+    var res = {};
+    var secretCallback = function (req, headers, payload, cb) {
+      process.nextTick(function () { return cb(null, null) });
     }
-    var token = jwt.sign({foo: 'bar'}, 'secret', {algorithm: "none"});
+    var token = jwt.sign({ foo: 'bar' }, 'secret', { algorithm: "none" });
 
     req.headers = {};
     req.headers.authorization = 'Bearer ' + token;
-    expressjwt({secret: secretCallback, algorithms: ["none"]})(req, res, function() {
+    expressjwt({ secret: secretCallback, algorithms: ["none"] })(req, res, function () {
       assert.equal('bar', req.user.foo);
       done();
     });


### PR DESCRIPTION
### Description
The "none" algorithm option has to be explicitly allowed to be used.

The former behavior is especially a problematic when this library is used in conjunction with `jwks-rsa` and the `expressJwtSecret` function which will return an empty secret for tokens signed with `none` which in turn will change the jwt validation behavior to not require a signing key.

See 
### References
https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/ 


### Testing
See added unit tests. 
- [x] This change adds test coverage for new/changed/fixed functionality


### Checklist
- [x] All active GitHub checks for tests, formatting, and security are passing

