### PR TITLE
Update express-unless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -858,9 +858,9 @@
       "dev": true
     },
     "express-unless": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.0.tgz",
-      "integrity": "sha1-XHlec5JXFRLdKPUgs4V6UrISYaI="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.5.0.tgz",
+      "integrity": "sha1-wuzkd/QVUIkUPbuGnQfFfF62q5s="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "main": "./lib",
   "dependencies": {
     "async": "^1.5.0",
-    "express-unless": "^0.3.0",
+    "express-unless": "^0.5.0",
     "jsonwebtoken": "^8.1.0",
     "lodash.set": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-jwt",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "JWT authentication middleware.",
   "keywords": [
     "auth",

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -178,7 +178,7 @@ describe('failure tests', function () {
       var secret = "shhh";
       var token = jwt.sign({foo: 'bar', iss: 'http://www'}, secret);
       // manipulate the token
-      var newContent = new Buffer("{foo: 'bar', edg: 'ar'}").toString('base64');
+      var newContent = new Buffer.from("{foo: 'bar', edg: 'ar'}").toString('base64');
       var splitetToken = token.split(".");
       splitetToken[1] = newContent;
       var newToken = splitetToken.join(".");
@@ -248,7 +248,7 @@ describe('work tests', function () {
   });
 
   it('should work if authorization header is valid with a buffer secret', function() {
-    var secret = new Buffer('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'base64');
+    var secret = new Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'base64');
     var token = jwt.sign({foo: 'bar'}, secret);
 
     req.headers = {};


### PR DESCRIPTION
Updates dependency on `express-unless` to 0.5.0 which allows `.unless` chains. This allows you to configure custom/optional middleware handling per endpoint(s).

Example:
```javascript
app.use(
  jwt({
    secret: 'secret1',
    algorithms: ['HS256']
  }).unless({ 
    path: [
      { methods: ['POST'], url: '/user/login' },
      { methods: ['POST'], url: '/user/register' },
    ],
  }).unless({
    path: [
      { methods: ['GET'], url: '/optional/auth/endpoint' }
    ],
    custom: function(req) { 
      // Run middleware based on some custom condition(s)
    }
  }),
);
```

Also changed `Buffer()` to `Buffer.from()` in tests. This cleans up a console error when running tests.