### PR TITLE
feat: bring your own verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,42 @@ app.get('/protected',
 );
 ```
 
+### Bring Your Own Verify
+
+A custom function to verify a the incoming JWT token. This
+is especially useful if you require custom logic, want to add
+to `jsonwebtoken` options properties that we do not offer 
+or require specific versions of `jsonwebtoken`.
+
+```javascript
+const jsonwebtoken = require('jsonwebtoken');
+
+app.use(jwt({
+  secret: 'hello world !',
+  algorithms: ['HS256'],
+  credentialsRequired: false,
+  verify: function customVerify (req, token, secret, options, callback) {
+    const additionalOptions = { 
+      // additional, conditional options here
+    } 
+
+    const opts = Object.assign({}, options, additionalOptions);
+    
+    jsonwebtoken.verify(token, secret, options, function handlePostLogic(err, decodedToken) {
+      if (err) {
+        return callback(err);
+      }
+
+      if (blockedByBilling.get(decoded.sub)) {
+        return callback(new Error('blocked_by_billing'));
+      }
+
+      callback(null, decodedToken);
+    })
+  }
+}));
+```
+
 ### Error handling
 
 The default behavior is to throw an error when the token is invalid, so you can add your custom logic to manage unauthorized access as follows:

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,10 @@ module.exports = function(options) {
         }
       },
       function verifyToken(secret, callback) {
+        if (options.verify) {
+          return options.verify(req, token, secret, options, callback);
+        }
+
         jwt.verify(token, secret, options, function(err, decoded) {
           if (err) {
             callback(new UnauthorizedError('invalid_token', err));

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -345,6 +345,35 @@ describe('work tests', function () {
     });
   });
 
+  it('should work with a custom verify function', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    req.headers = {};
+    req.query = {};
+    req.query.token = token;
+
+    function getTokenFromQuery(req) {
+      return req.query.token;
+    }
+
+    function verify(req, verifyToken, verifySecret, options, callback) {
+      assert.equal(secret, verifySecret)
+      assert.equal(token, verifyToken)
+      assert.equal(req.query.token, token)
+      return callback(null, { foo: 'bar' })
+    }
+
+    expressjwt({
+      secret: secret,
+      algorithms: ['HS256'],
+      getToken: getTokenFromQuery,
+      verify: verify
+    })(req, res, function() {
+      assert.equal('bar', req.user.foo);
+    });
+  });
+
   it('should work with a secretCallback function that accepts header argument', function() {
     var secret = 'shhhhhh';
     var secretCallback = function(req, headers, payload, cb) {


### PR DESCRIPTION
Signed-off-by: Robert Jefe Lindstaedt <robert.lindstaedt@gmail.com>

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

As
- jsonwebtoken might move faster
- a developer needs more custom logic
- wants to use other libraries

we could allow a user to bring their own verify function. A concrete use case for us is more custom logic on the audience, that jsonwebtoken does not currently allow. 

### References

-

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
