### PR TITLE
Add example on how to enable jwt for specific path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ jwt({ secret: Buffer.from('shhhhhhared-secret', 'base64'),
       algorithms: ['RS256'] })
 ```
 
-Optionally you can make some paths unprotected as follows:
+To only protect specific paths (e.g. beginning with `/api`), use [express router](https://expressjs.com/en/4x/api.html#app.use) like so:
+
+```javascript
+app.use('/api', jwt({ secret: 'shhhhhhared-secret', algorithms: ['HS256']}));
+```
+
+Or, the other way around, if you want to to make some paths unprotected as follows:
 
 ```javascript
 app.use(jwt({ secret: 'shhhhhhared-secret', algorithms: ['HS256']}).unless({path: ['/token']}));

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ jwt({ secret: Buffer.from('shhhhhhared-secret', 'base64'),
       algorithms: ['RS256'] })
 ```
 
-To only protect specific paths (e.g. beginning with `/api`), use [express router](https://expressjs.com/en/4x/api.html#app.use) like so:
+To only protect specific paths (e.g. beginning with `/api`), use [express router](https://expressjs.com/en/4x/api.html#app.use) call `use`, like so:
 
 ```javascript
 app.use('/api', jwt({ secret: 'shhhhhhared-secret', algorithms: ['HS256']}));
 ```
 
-Or, the other way around, if you want to to make some paths unprotected as follows:
+Or, the other way around, if you want to make some paths unprotected, cal `unless` like so.
 
 ```javascript
 app.use(jwt({ secret: 'shhhhhhared-secret', algorithms: ['HS256']}).unless({path: ['/token']}));


### PR DESCRIPTION
### Description

Add example on how to enable jwt for specific path, as compared to _disabling_ for a specific path which was the only example shown before.

Some context as to why I feel this would help. People are doing various more or less miss-guided workarounds for this across the interwebs. See some examples here:
* https://stackoverflow.com/questions/31496439/express-jwt-not-respecting-unprotected-paths
* https://stackoverflow.com/questions/47670921/express-jwt-exclude-certain-routes
* https://medium.com/javascript-in-plain-english/verifying-json-web-tokens-with-express-jwt-1ae147aa9bd3