### PR TITLE
Fixed bug status code 200 returned for errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,18 +64,21 @@ module.exports = function(options) {
           token = credentials;
         } else {
           if (credentialsRequired) {
+            res.status(401)
             return next(new UnauthorizedError('credentials_bad_scheme', { message: 'Format is Authorization: Bearer [token]' }));
           } else {
             return next();
           }
         }
       } else {
+        res.status(401)
         return next(new UnauthorizedError('credentials_bad_format', { message: 'Format is Authorization: Bearer [token]' }));
       }
     }
 
     if (!token) {
       if (credentialsRequired) {
+        res.status(401)
         return next(new UnauthorizedError('credentials_required', { message: 'No authorization token was found' }));
       } else {
         return next();
@@ -87,6 +90,7 @@ module.exports = function(options) {
     try {
       dtoken = jwt.decode(token, { complete: true }) || {};
     } catch (err) {
+      res.status(401)
       return next(new UnauthorizedError('invalid_token', err));
     }
 
@@ -122,7 +126,10 @@ module.exports = function(options) {
       }
 
     ], function (err, result){
-      if (err) { return next(err); }
+      if (err) { 
+        res.status(err.status || 400)
+        return next(err);
+      }
       if (_resultProperty) {
         set(res, _resultProperty, result);
       } else {


### PR DESCRIPTION
When Auth is invalid or any generate error passed to next() in the middleware, the http response from express doesn't use the status / code set on UnauthorizedError, as a fix setting res.status before next ensures correct status code is returned