### PR TITLE
build(deps): required runtime types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "/dist"
   ],
   "dependencies": {
+    "@types/express-unless": "^0.5.3",
+    "@types/jsonwebtoken": "^8.5.8",
     "express-unless": "^1.0.0",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
-    "@types/express-unless": "^0.5.3",
-    "@types/jsonwebtoken": "^8.5.8",
     "@types/mocha": "^9.1.0",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",


### PR DESCRIPTION
By submitting an Issue to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

### Description

I updated from v6+`@types/express-jwt` to v7

When building, `tsc` complains that it cannot find types for `jsonwebtoken` and `express-unless`. They are both referenced in the `index.d.ts` and thus their type declarations should be made dependencies.

Presently, I had to install them myself in my project

### Reproduction

1. Install in project
2. `import { expressjwt as jwt } from 'express-jwt'`
3. Use it 
4. `tsc`

### Environment

> Please provide the following:

- **Version of this library used:** 7.7.0
- **Other relevant versions (language, server software, OS, browser):** typescript 4.6.3
