### PR TITLE
Fix tsc build error for express-unless

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as jwt from 'jsonwebtoken';
 import * as express from 'express';
-import expressUnless from 'express-unless';
+import * as expressUnless from 'express-unless';
 import { UnauthorizedError } from './errors/UnauthorizedError';
 
 /**

--- a/test/UnauthorizedError.test.ts
+++ b/test/UnauthorizedError.test.ts
@@ -1,5 +1,5 @@
 import { UnauthorizedError } from '../src/errors/UnauthorizedError';
-import assert from 'assert';
+import * as assert from 'assert';
 
 describe('Unauthorized Error', () => {
   const e = new UnauthorizedError('credentials_bad_format', new Error('a'));

--- a/test/jwt.test.ts
+++ b/test/jwt.test.ts
@@ -2,7 +2,7 @@
 import * as jwt from 'jsonwebtoken';
 import * as express from 'express';
 import { expressjwt, UnauthorizedError, ExpressJwtRequest, GetVerificationKey } from '../src';
-import assert from 'assert';
+import * as assert from 'assert';
 
 
 describe('failure tests', function () {

--- a/test/multitenancy.test.ts
+++ b/test/multitenancy.test.ts
@@ -1,7 +1,7 @@
 import * as jwt from 'jsonwebtoken';
 import * as express from 'express';
 import { expressjwt, ExpressJwtRequest, GetVerificationKey } from '../src';
-import assert from 'assert';
+import * as assert from 'assert';
 
 describe('multitenancy', function () {
   const req = {} as ExpressJwtRequest;

--- a/test/revocation.test.ts
+++ b/test/revocation.test.ts
@@ -1,7 +1,7 @@
 import * as jwt from 'jsonwebtoken';
 import * as express from 'express';
 import { expressjwt, ExpressJwtRequest } from '../src';
-import assert from 'assert';
+import * as assert from 'assert';
 
 describe('revoked jwts', function () {
   const secret = 'shhhhhh';

--- a/test/string_token.test.ts
+++ b/test/string_token.test.ts
@@ -1,7 +1,7 @@
 import * as jwt from 'jsonwebtoken';
 import * as express from 'express';
 import { expressjwt, ExpressJwtRequest } from '../src';
-import assert from 'assert';
+import * as assert from 'assert';
 
 
 describe('string tokens', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "outDir": "./dist",
     "allowJs": true,
     "target": "es5",
-    "esModuleInterop": true,
     "declaration": true
   },
   "include": [


### PR DESCRIPTION
### Description

Fixed build error when not using the `esModuleInterop` flag

> node_modules/express-jwt/dist/index.d.ts:3:8 - error TS1259: Module '"/home/runner/work/my-project/node_modules/@types/express-unless/index"' can only be default-imported using the 'esModuleInterop' flag
> 
> 3 import expressUnless from 'express-unless';
>          ~~~~~~~~~~~~~
> 
>   node_modules/@types/express-unless/index.d.ts:30:1
>     30 export = unless;
>        ~~~~~~~~~~~~~~~~
>     This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.

### References

Fixes https://github.com/auth0/express-jwt/issues/291