### PR TITLE
README: Fix misspelled word in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To only protect specific paths (e.g. beginning with `/api`), use [express router
 app.use("/api", jwt({ secret: "shhhhhhared-secret", algorithms: ["HS256"] }));
 ```
 
-Or, the other way around, if you want to make some paths unprotected, cal `unless` like so.
+Or, the other way around, if you want to make some paths unprotected, call `unless` like so.
 
 ```javascript
 app.use(


### PR DESCRIPTION
### Description

Fixed misspelled word in README

### References
Github Issue: https://github.com/auth0/express-jwt/issues/299

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
