### PR TITLE
update GetVerificationKey type to match node-jwks-rsa

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { UnauthorizedError } from './errors/UnauthorizedError';
 /**
  * A function that defines how to retrieve the verification key given the express request and the JWT.
  */
-export type GetVerificationKey = (req: express.Request, token: jwt.Jwt | undefined) => jwt.Secret | Promise<jwt.Secret>;
+export type GetVerificationKey = (req: express.Request, token: jwt.Jwt | undefined) => jwt.Secret | undefined | Promise<jwt.Secret | undefined>;
 
 /**
  * @deprecated use GetVerificationKey


### PR DESCRIPTION
### Description

A [PR was recently merged](https://github.com/auth0/node-jwks-rsa/pull/329) to auth0/node-jwks-rsa that changed the type of `GetVerificationKey`, which breaks the interaction with express-jwt. This PR updates the type here to match the change there.


### References

- [Issue that led to node-jwks-rsa change](https://github.com/auth0/node-jwks-rsa/issues/328
- [PR of the actual change](https://github.com/auth0/node-jwks-rsa/pull/329)
- Fixes #304 

### Testing

None, does this need a test?

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
