### PR TITLE
feat: export middleware options type. closes #308

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export type IsRevoked = (req: express.Request, token: jwt.Jwt | undefined) => bo
  */
 export type TokenGetter = (req: express.Request) => string | Promise<string> | undefined;
 
-type Params = {
+export type Params = {
   /**
    * The Key or a function to retrieve the key used to verify the JWT.
    */


### PR DESCRIPTION
### Description
It makes it possible to import `Params` type of the middleware function

### References

#308 

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
