### PR TITLE
Update @types/jsonwebtoken to latest version and make dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,7 @@
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -147,7 +147,7 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
       "dev": true,
       "license": "MIT",
@@ -160,7 +160,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
       "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "license": "MIT",
@@ -181,7 +181,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -199,14 +199,14 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -221,7 +221,7 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -239,14 +239,14 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true,
       "license": "BSD-3-Clause"
@@ -262,7 +262,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
@@ -276,7 +276,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
@@ -286,7 +286,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
@@ -300,42 +300,42 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
       "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.10",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/json-schema/-/json-schema-7.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
       "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "8.5.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
       "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
       "license": "MIT",
       "dependencies": {
@@ -350,14 +350,14 @@
     },
     "node_modules/@types/mocha": {
       "version": "9.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/mocha/-/mocha-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
       "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "17.0.21",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/node/-/node-17.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "license": "MIT"
     },
@@ -369,7 +369,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz",
       "integrity": "sha512-u6Db5JfF0Esn3tiAKELvoU5TpXVSkOpZ78cEGn/wXtT2RVqs2vkt4ge6N8cRCyw7YVKhmmLDbwI2pg92mlv7cA==",
       "dev": true,
       "license": "MIT",
@@ -403,7 +403,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -421,14 +421,14 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
       "version": "7.3.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "license": "ISC",
@@ -444,7 +444,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/parser/-/parser-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.15.0.tgz",
       "integrity": "sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -472,7 +472,7 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -490,14 +490,14 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
       "integrity": "sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==",
       "dev": true,
       "license": "MIT",
@@ -515,7 +515,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz",
       "integrity": "sha512-KGeDoEQ7gHieLydujGEFLyLofipe9PIzfvA/41urz4hv+xVxPEbmMQonKSynZ0Ks2xDhJQ4VYjB3DnRiywvKDA==",
       "dev": true,
       "license": "MIT",
@@ -542,7 +542,7 @@
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -560,14 +560,14 @@
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/types/-/types-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.15.0.tgz",
       "integrity": "sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==",
       "dev": true,
       "license": "MIT",
@@ -581,7 +581,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
       "integrity": "sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -609,7 +609,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -627,14 +627,14 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.3.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "license": "ISC",
@@ -650,7 +650,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/utils/-/utils-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.15.0.tgz",
       "integrity": "sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==",
       "dev": true,
       "license": "MIT",
@@ -675,7 +675,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
       "integrity": "sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==",
       "dev": true,
       "license": "MIT",
@@ -693,7 +693,7 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/accepts/-/accepts-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "license": "MIT",
@@ -707,7 +707,7 @@
     },
     "node_modules/acorn": {
       "version": "8.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn/-/acorn-8.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
       "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true,
       "license": "MIT",
@@ -720,7 +720,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -730,7 +730,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "license": "MIT",
@@ -746,7 +746,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
@@ -809,7 +809,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/arg/-/arg-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
@@ -822,7 +822,7 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true,
       "license": "MIT"
@@ -835,7 +835,7 @@
     },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/array-union/-/array-union-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
       "license": "MIT",
@@ -854,7 +854,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
@@ -870,7 +870,7 @@
     },
     "node_modules/body-parser": {
       "version": "1.19.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/body-parser/-/body-parser-1.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
       "dev": true,
       "license": "MIT",
@@ -892,7 +892,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
@@ -903,7 +903,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/braces/-/braces-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "license": "MIT",
@@ -922,13 +922,13 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "license": "MIT",
@@ -938,7 +938,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
@@ -1068,14 +1068,14 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/content-disposition/-/content-disposition-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
       "license": "MIT",
@@ -1088,7 +1088,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true,
       "license": "MIT",
@@ -1331,7 +1331,7 @@
     },
     "node_modules/cookie": {
       "version": "0.4.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookie/-/cookie-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true,
       "license": "MIT",
@@ -1341,7 +1341,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true,
       "license": "MIT"
@@ -1354,14 +1354,14 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/create-require/-/create-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "license": "MIT",
@@ -1394,7 +1394,7 @@
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
@@ -1435,14 +1435,14 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/depd": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true,
       "license": "MIT",
@@ -1452,7 +1452,7 @@
     },
     "node_modules/destroy": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true,
       "license": "MIT"
@@ -1468,7 +1468,7 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "license": "MIT",
@@ -1481,7 +1481,7 @@
     },
     "node_modules/dir-glob/node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-type/-/path-type-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
@@ -1491,7 +1491,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1516,7 +1516,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1525,7 +1525,7 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true,
       "license": "MIT"
@@ -1538,7 +1538,7 @@
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true,
       "license": "MIT",
@@ -1566,7 +1566,7 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true,
       "license": "MIT"
@@ -1585,7 +1585,7 @@
     },
     "node_modules/eslint": {
       "version": "8.11.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint/-/eslint-8.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
       "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
       "dev": true,
       "license": "MIT",
@@ -1638,7 +1638,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1652,7 +1652,7 @@
     },
     "node_modules/eslint-utils": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "license": "MIT",
@@ -1671,7 +1671,7 @@
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1681,7 +1681,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1691,7 +1691,7 @@
     },
     "node_modules/eslint/node_modules/debug": {
       "version": "4.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "license": "MIT",
@@ -1709,7 +1709,7 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1723,7 +1723,7 @@
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1733,7 +1733,7 @@
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1746,14 +1746,14 @@
     },
     "node_modules/eslint/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
       "version": "9.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/espree/-/espree-9.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1768,7 +1768,7 @@
     },
     "node_modules/esquery": {
       "version": "1.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esquery/-/esquery-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1781,7 +1781,7 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1791,7 +1791,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1804,7 +1804,7 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1814,7 +1814,7 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1824,7 +1824,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1834,7 +1834,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true,
       "license": "MIT",
@@ -1844,7 +1844,7 @@
     },
     "node_modules/express": {
       "version": "4.17.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/express/-/express-4.17.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
       "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
       "dev": true,
       "license": "MIT",
@@ -1891,14 +1891,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-glob/-/fast-glob-3.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "license": "MIT",
@@ -1915,21 +1915,21 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.13.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fastq/-/fastq-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "license": "ISC",
@@ -1939,7 +1939,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
@@ -1952,7 +1952,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "license": "MIT",
@@ -1965,7 +1965,7 @@
     },
     "node_modules/finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "license": "MIT",
@@ -2009,7 +2009,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/flat-cache/-/flat-cache-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "license": "MIT",
@@ -2023,14 +2023,14 @@
     },
     "node_modules/flatted": {
       "version": "3.2.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/flatted/-/flatted-3.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
       "license": "MIT",
@@ -2040,7 +2040,7 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true,
       "license": "MIT",
@@ -2050,7 +2050,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "license": "ISC"
@@ -2077,7 +2077,7 @@
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true,
       "license": "MIT"
@@ -2237,7 +2237,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -2250,7 +2250,7 @@
     },
     "node_modules/globals": {
       "version": "13.13.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/globals/-/globals-13.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
       "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "license": "MIT",
@@ -2266,7 +2266,7 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/globby/-/globby-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "license": "MIT",
@@ -2365,7 +2365,7 @@
     },
     "node_modules/http-errors": {
       "version": "1.8.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-errors/-/http-errors-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
       "license": "MIT",
@@ -2382,7 +2382,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "license": "MIT",
@@ -2395,7 +2395,7 @@
     },
     "node_modules/ignore": {
       "version": "5.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ignore/-/ignore-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "license": "MIT",
@@ -2405,7 +2405,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "license": "MIT",
@@ -2422,7 +2422,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "license": "MIT",
@@ -2441,7 +2441,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "license": "ISC",
@@ -2452,7 +2452,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
@@ -2465,7 +2465,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
@@ -2505,7 +2505,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
@@ -2524,7 +2524,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -2537,7 +2537,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
@@ -2595,7 +2595,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "license": "ISC"
@@ -2632,14 +2632,14 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true,
       "license": "MIT"
@@ -2677,7 +2677,7 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "dependencies": {
         "jws": "^3.2.2",
@@ -2692,13 +2692,13 @@
     },
     "node_modules/jsonwebtoken/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "7.3.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2712,7 +2712,7 @@
     },
     "node_modules/jwa": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwa/-/jwa-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "license": "MIT",
       "dependencies": {
@@ -2723,7 +2723,7 @@
     },
     "node_modules/jws": {
       "version": "3.2.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jws/-/jws-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "license": "MIT",
       "dependencies": {
@@ -2742,7 +2742,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -2812,7 +2812,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
@@ -2835,7 +2835,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "dependencies": {
@@ -2847,7 +2847,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/make-error/-/make-error-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
@@ -2866,7 +2866,7 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true,
       "license": "MIT",
@@ -3051,14 +3051,14 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
@@ -3068,7 +3068,7 @@
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true,
       "license": "MIT",
@@ -3078,7 +3078,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/micromatch/-/micromatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "license": "MIT",
@@ -3092,7 +3092,7 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
       "license": "MIT",
@@ -3105,7 +3105,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
@@ -3115,7 +3115,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
@@ -3169,7 +3169,7 @@
     },
     "node_modules/mocha": {
       "version": "10.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mocha/-/mocha-10.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "dependencies": {
@@ -3205,7 +3205,7 @@
     },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
@@ -3214,7 +3214,7 @@
     },
     "node_modules/mocha/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
@@ -3231,13 +3231,13 @@
     },
     "node_modules/mocha/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/minimatch/-/minimatch-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
       "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
@@ -3264,14 +3264,14 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/nanoid/-/nanoid-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
@@ -3283,14 +3283,14 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/negotiator/-/negotiator-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
       "license": "MIT",
@@ -3345,7 +3345,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "license": "MIT",
@@ -3358,7 +3358,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "license": "ISC",
@@ -3368,7 +3368,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/optionator/-/optionator-0.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "license": "MIT",
@@ -3425,7 +3425,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
@@ -3451,7 +3451,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
       "license": "MIT",
@@ -3470,7 +3470,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "license": "MIT",
@@ -3480,7 +3480,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -3496,7 +3496,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true,
       "license": "MIT"
@@ -3524,7 +3524,7 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/picomatch/-/picomatch-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
@@ -3546,7 +3546,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -3556,7 +3556,7 @@
     },
     "node_modules/prettier": {
       "version": "2.6.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/prettier/-/prettier-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
       "dev": true,
       "license": "MIT",
@@ -3578,7 +3578,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "license": "MIT",
@@ -3592,7 +3592,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
       "license": "MIT",
@@ -3612,7 +3612,7 @@
     },
     "node_modules/qs": {
       "version": "6.9.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.9.7.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3625,7 +3625,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
@@ -3664,7 +3664,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
       "license": "MIT",
@@ -3674,7 +3674,7 @@
     },
     "node_modules/raw-body": {
       "version": "2.4.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/raw-body/-/raw-body-2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
       "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
       "dev": true,
       "license": "MIT",
@@ -3841,7 +3841,7 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/regexpp/-/regexpp-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true,
       "license": "MIT",
@@ -3880,7 +3880,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
@@ -3890,7 +3890,7 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/reusify/-/reusify-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true,
       "license": "MIT",
@@ -3901,7 +3901,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "license": "ISC",
@@ -3917,7 +3917,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
@@ -3941,7 +3941,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
@@ -3961,14 +3961,14 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "license": "ISC",
@@ -3978,7 +3978,7 @@
     },
     "node_modules/send": {
       "version": "0.17.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/send/-/send-0.17.2.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
       "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
       "dev": true,
       "license": "MIT",
@@ -4003,7 +4003,7 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
@@ -4019,7 +4019,7 @@
     },
     "node_modules/serve-static": {
       "version": "1.14.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/serve-static/-/serve-static-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
       "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
       "dev": true,
       "license": "MIT",
@@ -4035,14 +4035,14 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -4055,7 +4055,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -4065,7 +4065,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
@@ -4137,7 +4137,7 @@
     },
     "node_modules/statuses": {
       "version": "1.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true,
       "license": "MIT",
@@ -4251,7 +4251,7 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true,
       "license": "MIT"
@@ -4273,7 +4273,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
@@ -4286,7 +4286,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
       "license": "MIT",
@@ -4305,7 +4305,7 @@
     },
     "node_modules/ts-node": {
       "version": "10.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ts-node/-/ts-node-10.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
       "license": "MIT",
@@ -4349,7 +4349,7 @@
     },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/diff/-/diff-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -4359,14 +4359,14 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tslib/-/tslib-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tsutils/-/tsutils-3.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "license": "MIT",
@@ -4382,7 +4382,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -4395,7 +4395,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-fest/-/type-fest-0.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
@@ -4408,7 +4408,7 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "license": "MIT",
@@ -4422,7 +4422,7 @@
     },
     "node_modules/typescript": {
       "version": "4.6.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/typescript/-/typescript-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4449,7 +4449,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "license": "MIT",
@@ -4459,7 +4459,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4475,7 +4475,7 @@
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true,
       "license": "MIT",
@@ -4485,14 +4485,14 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
       "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
       "dev": true,
       "license": "MIT"
@@ -4509,7 +4509,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true,
       "license": "MIT",
@@ -4534,7 +4534,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
       "license": "MIT",
@@ -4550,7 +4550,7 @@
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/workerpool/-/workerpool-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
       "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
@@ -4573,7 +4573,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "license": "ISC"
@@ -4598,7 +4598,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
@@ -4679,7 +4679,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yn/-/yn-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
@@ -4787,13 +4787,13 @@
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
       "dev": true
     },
     "@cspotcode/source-map-support": {
       "version": "0.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
       "dev": true,
       "requires": {
@@ -4802,7 +4802,7 @@
     },
     "@eslint/eslintrc": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
       "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "requires": {
@@ -4819,7 +4819,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -4828,7 +4828,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -4836,7 +4836,7 @@
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "requires": {
@@ -4847,7 +4847,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -4856,7 +4856,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -4864,7 +4864,7 @@
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
@@ -4876,7 +4876,7 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "requires": {
@@ -4886,13 +4886,13 @@
     },
     "@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
@@ -4902,37 +4902,37 @@
     },
     "@tsconfig/node10": {
       "version": "1.0.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
       "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.9",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
       "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
       "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
       "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.10",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/json-schema/-/json-schema-7.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
       "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
       "dev": true
     },
     "@types/jsonwebtoken": {
       "version": "8.5.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
       "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
       "requires": {
         "@types/node": "*"
@@ -4946,13 +4946,13 @@
     },
     "@types/mocha": {
       "version": "9.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/mocha/-/mocha-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
       "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true
     },
     "@types/node": {
       "version": "17.0.21",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/node/-/node-17.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "@types/normalize-package-data": {
@@ -4963,7 +4963,7 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz",
       "integrity": "sha512-u6Db5JfF0Esn3tiAKELvoU5TpXVSkOpZ78cEGn/wXtT2RVqs2vkt4ge6N8cRCyw7YVKhmmLDbwI2pg92mlv7cA==",
       "dev": true,
       "requires": {
@@ -4980,7 +4980,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -4989,13 +4989,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
@@ -5006,7 +5006,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/parser/-/parser-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.15.0.tgz",
       "integrity": "sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==",
       "dev": true,
       "requires": {
@@ -5018,7 +5018,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -5027,7 +5027,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -5035,7 +5035,7 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
       "integrity": "sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==",
       "dev": true,
       "requires": {
@@ -5045,7 +5045,7 @@
     },
     "@typescript-eslint/type-utils": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz",
       "integrity": "sha512-KGeDoEQ7gHieLydujGEFLyLofipe9PIzfvA/41urz4hv+xVxPEbmMQonKSynZ0Ks2xDhJQ4VYjB3DnRiywvKDA==",
       "dev": true,
       "requires": {
@@ -5056,7 +5056,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -5065,7 +5065,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -5073,13 +5073,13 @@
     },
     "@typescript-eslint/types": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/types/-/types-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.15.0.tgz",
       "integrity": "sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
       "integrity": "sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==",
       "dev": true,
       "requires": {
@@ -5094,7 +5094,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -5103,13 +5103,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
@@ -5120,7 +5120,7 @@
     },
     "@typescript-eslint/utils": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/utils/-/utils-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.15.0.tgz",
       "integrity": "sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==",
       "dev": true,
       "requires": {
@@ -5134,7 +5134,7 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "5.15.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
       "integrity": "sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==",
       "dev": true,
       "requires": {
@@ -5144,7 +5144,7 @@
     },
     "accepts": {
       "version": "1.3.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/accepts/-/accepts-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "requires": {
@@ -5154,20 +5154,20 @@
     },
     "acorn": {
       "version": "8.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn/-/acorn-8.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
       "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
@@ -5179,7 +5179,7 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
@@ -5222,7 +5222,7 @@
     },
     "arg": {
       "version": "4.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/arg/-/arg-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
@@ -5234,7 +5234,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -5246,7 +5246,7 @@
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/array-union/-/array-union-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
@@ -5258,7 +5258,7 @@
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
@@ -5270,7 +5270,7 @@
     },
     "body-parser": {
       "version": "1.19.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/body-parser/-/body-parser-1.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
       "dev": true,
       "requires": {
@@ -5288,7 +5288,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -5298,7 +5298,7 @@
     },
     "braces": {
       "version": "3.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/braces/-/braces-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
@@ -5313,18 +5313,18 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bytes": {
       "version": "3.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
@@ -5420,13 +5420,13 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/content-disposition/-/content-disposition-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
       "requires": {
@@ -5435,7 +5435,7 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
@@ -5622,13 +5622,13 @@
     },
     "cookie": {
       "version": "0.4.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookie/-/cookie-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
@@ -5640,13 +5640,13 @@
     },
     "create-require": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/create-require/-/create-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
@@ -5669,7 +5669,7 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
@@ -5702,19 +5702,19 @@
     },
     "deep-is": {
       "version": "0.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
@@ -5726,7 +5726,7 @@
     },
     "dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "requires": {
@@ -5735,7 +5735,7 @@
       "dependencies": {
         "path-type": {
           "version": "4.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-type/-/path-type-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
@@ -5743,7 +5743,7 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
@@ -5761,7 +5761,7 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -5769,7 +5769,7 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
@@ -5781,7 +5781,7 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
@@ -5802,7 +5802,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
@@ -5814,7 +5814,7 @@
     },
     "eslint": {
       "version": "8.11.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint/-/eslint-8.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
       "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
       "dev": true,
       "requires": {
@@ -5857,7 +5857,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
@@ -5866,7 +5866,7 @@
         },
         "eslint-scope": {
           "version": "7.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
           "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
           "dev": true,
           "requires": {
@@ -5876,13 +5876,13 @@
         },
         "estraverse": {
           "version": "5.3.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         },
         "glob-parent": {
           "version": "6.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/glob-parent/-/glob-parent-6.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
@@ -5891,7 +5891,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -5899,7 +5899,7 @@
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
@@ -5909,7 +5909,7 @@
     },
     "eslint-utils": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "requires": {
@@ -5918,7 +5918,7 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "2.1.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         }
@@ -5926,13 +5926,13 @@
     },
     "eslint-visitor-keys": {
       "version": "3.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "espree": {
       "version": "9.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/espree/-/espree-9.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "requires": {
@@ -5943,7 +5943,7 @@
     },
     "esquery": {
       "version": "1.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esquery/-/esquery-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
@@ -5952,7 +5952,7 @@
       "dependencies": {
         "estraverse": {
           "version": "5.3.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
@@ -5960,7 +5960,7 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
@@ -5969,7 +5969,7 @@
       "dependencies": {
         "estraverse": {
           "version": "5.3.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
@@ -5977,25 +5977,25 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "express": {
       "version": "4.17.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/express/-/express-4.17.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
       "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
       "dev": true,
       "requires": {
@@ -6038,13 +6038,13 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-glob/-/fast-glob-3.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
@@ -6057,19 +6057,19 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
       "version": "1.13.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fastq/-/fastq-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
@@ -6078,7 +6078,7 @@
     },
     "file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
@@ -6087,7 +6087,7 @@
     },
     "fill-range": {
       "version": "7.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
@@ -6096,7 +6096,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
@@ -6127,7 +6127,7 @@
     },
     "flat-cache": {
       "version": "3.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/flat-cache/-/flat-cache-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
@@ -6137,25 +6137,25 @@
     },
     "flatted": {
       "version": "3.2.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/flatted/-/flatted-3.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "forwarded": {
       "version": "0.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -6174,7 +6174,7 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -6304,7 +6304,7 @@
     },
     "glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
@@ -6313,7 +6313,7 @@
     },
     "globals": {
       "version": "13.13.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/globals/-/globals-13.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
       "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "requires": {
@@ -6322,7 +6322,7 @@
     },
     "globby": {
       "version": "11.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/globby/-/globby-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
@@ -6391,7 +6391,7 @@
     },
     "http-errors": {
       "version": "1.8.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-errors/-/http-errors-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
       "requires": {
@@ -6404,7 +6404,7 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
@@ -6413,13 +6413,13 @@
     },
     "ignore": {
       "version": "5.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ignore/-/ignore-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "requires": {
@@ -6429,7 +6429,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -6441,7 +6441,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -6451,7 +6451,7 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
@@ -6463,7 +6463,7 @@
     },
     "ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
@@ -6493,7 +6493,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
@@ -6505,7 +6505,7 @@
     },
     "is-glob": {
       "version": "4.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
@@ -6514,7 +6514,7 @@
     },
     "is-number": {
       "version": "7.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
@@ -6553,7 +6553,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -6586,13 +6586,13 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
@@ -6620,7 +6620,7 @@
     },
     "jsonwebtoken": {
       "version": "9.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "requires": {
         "jws": "^3.2.2",
@@ -6631,12 +6631,12 @@
       "dependencies": {
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "semver": {
           "version": "7.3.8",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
@@ -6646,7 +6646,7 @@
     },
     "jwa": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwa/-/jwa-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
@@ -6656,7 +6656,7 @@
     },
     "jws": {
       "version": "3.2.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jws/-/jws-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
@@ -6671,7 +6671,7 @@
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
@@ -6727,7 +6727,7 @@
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
@@ -6743,7 +6743,7 @@
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
@@ -6751,7 +6751,7 @@
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/make-error/-/make-error-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
@@ -6763,7 +6763,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -6902,25 +6902,25 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "micromatch": {
       "version": "4.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/micromatch/-/micromatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "requires": {
@@ -6930,19 +6930,19 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
       "version": "1.52.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
@@ -6983,7 +6983,7 @@
     },
     "mocha": {
       "version": "10.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mocha/-/mocha-10.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
@@ -7012,7 +7012,7 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
@@ -7021,7 +7021,7 @@
         },
         "debug": {
           "version": "4.3.4",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
           "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
@@ -7030,7 +7030,7 @@
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
               "dev": true
             }
@@ -7038,7 +7038,7 @@
         },
         "minimatch": {
           "version": "5.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/minimatch/-/minimatch-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
           "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
@@ -7061,25 +7061,25 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "nanoid": {
       "version": "3.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/nanoid/-/nanoid-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/negotiator/-/negotiator-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true
     },
@@ -7120,7 +7120,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -7129,7 +7129,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -7138,7 +7138,7 @@
     },
     "optionator": {
       "version": "0.9.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/optionator/-/optionator-0.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
@@ -7176,7 +7176,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
@@ -7195,7 +7195,7 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
@@ -7207,13 +7207,13 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
@@ -7225,7 +7225,7 @@
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
@@ -7248,7 +7248,7 @@
     },
     "picomatch": {
       "version": "2.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/picomatch/-/picomatch-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
@@ -7260,13 +7260,13 @@
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "prettier": {
       "version": "2.6.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/prettier/-/prettier-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
       "dev": true
     },
@@ -7278,7 +7278,7 @@
     },
     "proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "requires": {
@@ -7288,7 +7288,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
@@ -7300,13 +7300,13 @@
     },
     "qs": {
       "version": "6.9.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.9.7.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
       "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
@@ -7327,13 +7327,13 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
     "raw-body": {
       "version": "2.4.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/raw-body/-/raw-body-2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
       "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
       "dev": true,
       "requires": {
@@ -7467,7 +7467,7 @@
     },
     "regexpp": {
       "version": "3.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/regexpp/-/regexpp-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
@@ -7490,19 +7490,19 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/reusify/-/reusify-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
@@ -7511,7 +7511,7 @@
     },
     "run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "requires": {
@@ -7520,24 +7520,24 @@
     },
     "safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "send": {
       "version": "0.17.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/send/-/send-0.17.2.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
       "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
       "dev": true,
       "requires": {
@@ -7558,7 +7558,7 @@
       "dependencies": {
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
@@ -7575,7 +7575,7 @@
     },
     "serve-static": {
       "version": "1.14.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/serve-static/-/serve-static-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
       "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
       "dev": true,
       "requires": {
@@ -7587,13 +7587,13 @@
     },
     "setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
@@ -7602,13 +7602,13 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
@@ -7670,7 +7670,7 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
@@ -7747,7 +7747,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -7768,7 +7768,7 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
@@ -7777,7 +7777,7 @@
     },
     "toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
@@ -7789,7 +7789,7 @@
     },
     "ts-node": {
       "version": "10.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ts-node/-/ts-node-10.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
       "requires": {
@@ -7810,7 +7810,7 @@
       "dependencies": {
         "diff": {
           "version": "4.0.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/diff/-/diff-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
@@ -7818,13 +7818,13 @@
     },
     "tslib": {
       "version": "1.14.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tslib/-/tslib-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tsutils/-/tsutils-3.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "requires": {
@@ -7833,7 +7833,7 @@
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
@@ -7842,13 +7842,13 @@
     },
     "type-fest": {
       "version": "0.20.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-fest/-/type-fest-0.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "requires": {
@@ -7858,7 +7858,7 @@
     },
     "typescript": {
       "version": "4.6.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/typescript/-/typescript-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
@@ -7871,13 +7871,13 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
@@ -7892,19 +7892,19 @@
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
       "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
       "dev": true
     },
@@ -7920,7 +7920,7 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
@@ -7935,7 +7935,7 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
@@ -7947,7 +7947,7 @@
     },
     "workerpool": {
       "version": "6.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/workerpool/-/workerpool-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
       "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
@@ -7964,7 +7964,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -7982,7 +7982,7 @@
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
@@ -8040,7 +8040,7 @@
     },
     "yn": {
       "version": "3.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yn/-/yn-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
-        "@types/jsonwebtoken": "^8.5.8",
         "express-unless": "^2.1.3",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.0",
         "@types/mocha": "^9.1.0",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
@@ -334,10 +334,10 @@
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
-      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
-      "license": "MIT",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -359,6 +359,7 @@
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -4931,9 +4932,10 @@
       "dev": true
     },
     "@types/jsonwebtoken": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
-      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -4953,7 +4955,8 @@
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "/dist"
   ],
   "dependencies": {
-    "@types/jsonwebtoken": "^8.5.8",
     "express-unless": "^2.1.3",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.0",
     "@types/mocha": "^9.1.0",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This updates the `jsonwebtoken` types to match the new `9.0.0` version

- Also moved to `devDependencies` as the types shouldn't be installed as a dependency (unless I'm missing something)
- Updated package-lock.json to replace `jfrog` repo with `npm`. This is due to an auth error requiring jfrog credentials during `npm install`
  - I've made this a separate commit so the changes can be seen with only the URL changing with no packages or integrity strings


### References

Types PR merged here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63710

### Testing

N/A - dev dependency

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
