### PR TITLE
Move back to lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,10 @@
         "@types/jsonwebtoken": "^9",
         "express-unless": "^2.1.3",
         "jsonwebtoken": "^9.0.0",
-        "lodash.set": "^4.3.2"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.191",
-        "@types/lodash.set": "^4.3.7",
         "@types/mocha": "^9.1.0",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
@@ -318,15 +317,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash.set": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.7.tgz",
-      "integrity": "sha512-bS5Wkg/nrT82YUfkNYPSccFrNZRL+irl7Yt4iM6OTSQ0VZJED2oUIVm15NkNtUAQ8SRhCe+axqERUV6MJgkeEg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -2660,11 +2650,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -4775,15 +4760,6 @@
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
-    "@types/lodash.set": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.7.tgz",
-      "integrity": "sha512-bS5Wkg/nrT82YUfkNYPSccFrNZRL+irl7Yt4iM6OTSQ0VZJED2oUIVm15NkNtUAQ8SRhCe+axqERUV6MJgkeEg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -6560,11 +6536,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,10 @@
     "@types/jsonwebtoken": "^9",
     "express-unless": "^2.1.3",
     "jsonwebtoken": "^9.0.0",
-    "lodash.set": "^4.3.2"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",
-    "@types/lodash.set": "^4.3.7",
     "@types/mocha": "^9.1.0",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import * as express from 'express';
 import { unless } from 'express-unless';
-import set from 'lodash.set';
+import set from 'lodash/set';
 
 import { UnauthorizedError } from './errors/UnauthorizedError';
 


### PR DESCRIPTION
### Description

See #316 and #271.  Closes security vulnerability by re-adopting main lodash package.

### Testing

No changes in functionality.

### Checklist

- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
