### PR TITLE
Move @types/jsonwebtoken to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "8.4.1",
       "license": "MIT",
       "dependencies": {
-        "@types/jsonwebtoken": "^9",
         "express-unless": "^2.1.3",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.16",
+        "@types/jsonwebtoken": "^9",
         "@types/mocha": "^9.1.0",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
@@ -349,6 +349,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -374,7 +375,8 @@
     "node_modules/@types/node": {
       "version": "18.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -4855,6 +4857,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -4880,7 +4883,8 @@
     "@types/node": {
       "version": "18.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "/dist"
   ],
   "dependencies": {
-    "@types/jsonwebtoken": "^9",
     "express-unless": "^2.1.3",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.16",
+    "@types/jsonwebtoken": "^9",
     "@types/mocha": "^9.1.0",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This prevents dependencies (the usual non-dev dependencies) in downstream TypeScript projects from getting polluted with compile-time-only `@types`. It should fix https://github.com/auth0/express-jwt/issues/323 without impacting anything else. The build succeeds and passes. 

### References

https://github.com/auth0/express-jwt/issues/323

### Testing

1. Create a TypeScript project that uses `express-jwt` in production dependencies and `@types/jsonwebtoken` in devDependencies.
2. `npm install`. Note that there are now `@types` in prod dependencies by examining `package-lock.json`.
3. Try the same again with the changes and note that fewer `@types` arrive in prod.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
