### PR TITLE
fix: corrected files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "/dist"
+    "dist"
   ],
   "dependencies": {
     "@types/jsonwebtoken": "^9",


### PR DESCRIPTION
### Description

Fixed files in package.json so that pnpm installs correctly. See https://github.com/auth0/express-jwt/issues/326

## Testing

Create a project with pnpm

> mkdir test
> cd test
> pnpm init
> pnpm i express-jwt

Check the contents of node_modules

> ls node_modules/express-jwt
> LICENSE  package.json  README.md

The dist folder will be missing

Build express jwt from the fix

> npm run build
> npm pack

This should generate a file  express-jwt-8.4.1.tgz. Update the package json file

...
     "express-jwt": "file:/....path-to-file/express-jwt-8.4.1.tgz"
...

> pnpm i

Check the installed express-jwt folder under node_modules and you should see

> ls node_modules/express-jwt
> dist  LICENSE  package.json  README.md

### Checklist

- [x ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x ] All active GitHub checks for tests, formatting, and security are passing
- [x ] The correct base branch is being used, if not the default branch
