### PR TITLE
Fix readme inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you need to obtain the key dynamically from other sources, you can pass a fun
 For example, if the secret varies based on the [issuer](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#issDef):
 
 ```javascript
-var jwt = require("express-jwt");
+var { expressjwt: jwt } = require("express-jwt");
 var data = require("./data");
 var utilities = require("./utilities");
 
@@ -201,7 +201,7 @@ It is possible that some tokens will need to be revoked so they cannot be used a
 For example, if the `(iss, jti)` claim pair is used to identify a JWT:
 
 ```javascript
-const jwt = require("express-jwt");
+const { expressjwt: jwt } = require("express-jwt");
 const data = require("./data");
 
 const isRevokedCallback = async (req, token) => {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

I noted little inconsistency in the readme docs. It's said that for migration to V6 instead of default export:
```javascript
var jwt = require("express-jwt");
```

It should be:
```javascript
var { expressjwt: jwt } = require("express-jwt");
``` 

So, I fixed that in 2 places in Readme

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
