### PR TITLE
Add optionalToken parameter to middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,5 +218,3 @@ export const expressjwt = (options: Params) => {
 
   return middleware;
 }
-
-


### PR DESCRIPTION
### Description
I thought about adding a parameter to allow for tokens to be read, while still allowing tokens to be retired, expired, invalid, or non existent without anything being thrown. If a valid token can be decoded, it'll be returned. The PR does not break anything as it's false by default, so existing implementations will still work.

### References
I figured I'd do this due to my own personal need, as well as a couple of discussions within this repository, https://github.com/auth0/express-jwt/issues/194

### Testing
I've not yet got around to add tests. If someone would like to contribute with some, please do!

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
