### PR TITLE
docs(Readme): remove import of deprecated ExpressJwtRequest from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Basic usage using an HS256 secret:
 ```javascript
 var { expressjwt: jwt } = require("express-jwt");
 // or ES6
-// import { expressjwt, ExpressJwtRequest } from "express-jwt";
+// import { expressjwt } from "express-jwt";
 
 app.get(
   "/protected",


### PR DESCRIPTION
### Description
ExpressJwtRequest is depreceted since it breaks tsc when strict: true, but it still appears in the Readme example.
This PR simply removes it, to avoid confusing users.

### References
https://github.com/auth0/express-jwt/blob/f42a0e99422fe85fadd0a209b8497b64995e94cf/src/index.ts#L83