### PR TITLE
docs: replace deprecated ExpressJwtRequest in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Basic usage using an HS256 secret:
 ```javascript
 var { expressjwt: jwt } = require("express-jwt");
 // or ES6
-// import { expressjwt, ExpressJwtRequest } from "express-jwt";
+// import { expressjwt, Request as JWTRequest } from "express-jwt";
 
 app.get(
   "/protected",

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as assert from 'assert';
+
+describe('README', function () {
+  it('should not recommend the deprecated ExpressJwtRequest type', function () {
+    const readme = fs.readFileSync(path.join(process.cwd(), 'README.md'), 'utf8');
+    assert.equal(
+      /import\s*\{[^}]*\bExpressJwtRequest\b[^}]*\}\s*from\s*["']express-jwt["']/.test(readme),
+      false
+    );
+  });
+});


### PR DESCRIPTION
Replace the Usage ES6 import of `ExpressJwtRequest` with `Request as JWTRequest`, matching the TypeScript section of the same README. Add a README assertion so a deprecated `express-jwt` import of `ExpressJwtRequest` fails the test suite.

Closes #341

## Provenance

`ExpressJwtRequest` was deprecated for breaking `tsc` with `strict: true`, in favor of `Request` with optional `auth` (#284). José F. Romaniello: use that type always. The TypeScript section was updated in that work and later clarified in 8.3.0 (`3c1d5cf`); the Usage ES6 line was missed.

## Decision

The Usage ES6 line imports `Request as JWTRequest`, the smallest change that matches the TypeScript section already in this README. Alternative: drop the type from the JavaScript Usage import (`import { expressjwt } from "express-jwt"`). Can drop the type from Usage instead if that sample should stay untyped.

`test/readme.test.ts` is a mocha assertion over the README import. Alternative: README-only, as in `3c1d5cf`. The regression is a one-line docs drift that already survived one deprecation pass. Can drop `test/readme.test.ts` if you would rather not snapshot the README.

Internal tests still import the deprecated alias; they were left alone because the type remains exported.

## Test plan

- [x] README Usage ES6 import no longer names `ExpressJwtRequest`
- [x] README TypeScript section still uses `Request as JWTRequest`
- [x] `npx mocha --reporter spec --require ts-node/register test/readme.test.ts` fails with the old Usage line and passes with the new one
- [x] `npm test`: 42 passing
